### PR TITLE
Aberration without aberration

### DIFF
--- a/pixell/aberration.py
+++ b/pixell/aberration.py
@@ -65,8 +65,6 @@ def apply_modulation(imap, A, T0=T_cmb, freq=150e9, map_unit=1e-6, mode="thermo"
 	if    mode is None:     return imap
 	elif  mode == "plain":  return imap*A
 	elif  mode == "thermo":
-                import pdb
-                pdb.set_trace()
 		# We're in linearized thermodynamic units. We assume that the map doesn't contain the
 		# monopole, so we can treat it as a perturbation around the monopole. If the map
 		# contains the monopole, then linearized units probably isn't the best choice


### PR DESCRIPTION
Added an option to aberration.boost_map to do the modulation without the aberration.  Previously, the converse was possible (aberration without modulation).  I needed this because I store the aberrated maps ahead of time, but then when a sim is requested at a given frequency the modulation is done in real time. (since, in the expansion we are using, the modulation is frequency dependent and the aberration is not).

With do_aberration set to False, the routine will skip the aberration part and only apply the modulation factor.