### PR TITLE
Cut-sky geometry and some python 3 updates

### DIFF
--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -904,12 +904,12 @@ def band_geometry(dec_cut,res=None, shape=None, dims=(), proj="car"):
         raise ValueError
     ishape,iwcs = fullsky_geometry(res=res, shape=shape, dims=dims, proj=proj)
     start = sky2pix(ishape,iwcs,(dec_cut_min,0))[0]
-    end = sky2pix(ishape,iwcs,(dec_cut_max,0))[0]
+    stop = sky2pix(ishape,iwcs,(dec_cut_max,0))[0]
     Ny,_ = ishape[-2:]
     start = max(int(np.round(start)),0); stop = min(int(np.round(stop)),Ny)
     assert start>=0 and start<Ny
-    assert end>=0 and end<Ny
-    return slice_geometry(ishape,iwcs,np.s_[start:end,:])
+    assert stop>=0 and stop<Ny
+    return slice_geometry(ishape,iwcs,np.s_[start:stop,:])
 
 def create_wcs(shape, box=None, proj="cea"):
 	if box is None:

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -883,6 +883,29 @@ def fullsky_geometry(res=None, shape=None, dims=(), proj="car"):
 	wcs.wcs.ctype = ["RA---CAR","DEC--CAR"]
 	return dims+(ny+1,nx+0), wcs
 
+def cutsky_geometry(dec_cut,res=None, shape=None, dims=(), proj="car"):
+    """Return a geometry corresponding to a sky that had a full-sky
+    geometry but to which a declination cut was applied. If dec_cut
+    is a single number, the declination range will be (-dec_cut,dec_cut)
+    radians, and if specified with two components, it is interpreted as
+    (dec_cut_min,dec_cut_max). The remaining arguments are the same as
+    fullsky_geometry and pertain to the geometry before cropping to the
+    cut-sky.
+    """
+    dec_cut = np.asarray(dec_cut)
+    if dec_cut.size == 1:
+        dec_cut_min = -dec_cut[0]
+        dec_cut_max = dec_cut[0]
+        assert dec_cut_max>0
+    elif dec_cut.size == 2:
+        dec_cut_min,dec_cut_max = dec_cut
+    else:
+        raise ValueError
+    ishape,iwcs = fullsky_geometry(res=res, shape=shape, dims=dims, proj=proj)
+    sy = sky2pix(ishape,iwcs,(dec_cut_min,0))[0]
+    ey = sky2pix(ishape,iwcs,(dec_cut_max,0))[0]
+    return slice_geometry(ishape,iwcs,np.s_[sy:ey,:])
+
 def create_wcs(shape, box=None, proj="cea"):
 	if box is None:
 		box = np.array([[-1,-1],[1,1]])*0.5*10

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -883,7 +883,7 @@ def fullsky_geometry(res=None, shape=None, dims=(), proj="car"):
 	wcs.wcs.ctype = ["RA---CAR","DEC--CAR"]
 	return dims+(ny+1,nx+0), wcs
 
-def cutsky_geometry(dec_cut,res=None, shape=None, dims=(), proj="car"):
+def band_geometry(dec_cut,res=None, shape=None, dims=(), proj="car"):
     """Return a geometry corresponding to a sky that had a full-sky
     geometry but to which a declination cut was applied. If dec_cut
     is a single number, the declination range will be (-dec_cut,dec_cut)
@@ -899,12 +899,17 @@ def cutsky_geometry(dec_cut,res=None, shape=None, dims=(), proj="car"):
         assert dec_cut_max>0
     elif dec_cut.size == 2:
         dec_cut_min,dec_cut_max = dec_cut
+        assert dec_cut_max>dec_cut_min
     else:
         raise ValueError
     ishape,iwcs = fullsky_geometry(res=res, shape=shape, dims=dims, proj=proj)
-    sy = sky2pix(ishape,iwcs,(dec_cut_min,0))[0]
-    ey = sky2pix(ishape,iwcs,(dec_cut_max,0))[0]
-    return slice_geometry(ishape,iwcs,np.s_[sy:ey,:])
+    start = sky2pix(ishape,iwcs,(dec_cut_min,0))[0]
+    end = sky2pix(ishape,iwcs,(dec_cut_max,0))[0]
+    Ny,_ = ishape[-2:]
+    start = max(int(np.round(start)),0); stop = min(int(np.round(stop)),Ny)
+    assert start>=0 and start<Ny
+    assert end>=0 and end<Ny
+    return slice_geometry(ishape,iwcs,np.s_[start:end,:])
 
 def create_wcs(shape, box=None, proj="cea"):
 	if box is None:

--- a/pixell/utils.py
+++ b/pixell/utils.py
@@ -1,4 +1,6 @@
 import numpy as np, scipy.ndimage, os, errno, scipy.optimize, time, datetime, warnings, re, sys
+try: xrange
+except: xrange = range
 
 degree = np.pi/180
 arcmin = degree/60
@@ -439,7 +441,7 @@ def equal_split(weights, nbin):
 	weight in each bin is as close to equal as possible.
 	Returns a list of indices for each bin."""
 	inds = np.argsort(weights)[::-1]
-	bins = [[] for b in range(nbin)]
+	bins = [[] for b in xrange(nbin)]
 	bw   = np.zeros([nbin])
 	for i in inds:
 		j = np.argmin(bw)
@@ -543,12 +545,12 @@ def range_union(a, mapping=False):
 	rmap = np.zeros(n,dtype=int)-1
 	b    = []
 	# i will point at the first unprocessed range
-	for i in range(n):
+	for i in xrange(n):
 		if rmap[inds[i]] >= 0: continue
 		rmap[inds[i]] = len(b)
 		start, end = a[inds[i]]
 		# loop through every unprocessed range in range
-		for j in range(i+1,n):
+		for j in xrange(i+1,n):
 			if rmap[inds[j]] >= 0: continue
 			if a[inds[j],0] > end: break
 			# This range overlaps, so register it and merge
@@ -660,19 +662,19 @@ def greedy_split(data, n=2, costfun=max, workfun=lambda w,x: x if w is None else
 	# Sort data based on standalone costs
 	costs = []
 	nowork = workfun(None,None)
-	work = [nowork for i in range(n)]
+	work = [nowork for i in xrange(n)]
 	for d in data:
 		work[0] = workfun(nowork,d)
 		costs.append(costfun(work))
 	order = np.argsort(costs)[::-1]
 	# Build groups using greedy algorithm
-	groups = [[] for i in range(n)]
-	work   = [nowork for i in range(n)]
+	groups = [[] for i in xrange(n)]
+	work   = [nowork for i in xrange(n)]
 	cost   = costfun(work)
 	for di in order:
 		d = data[di]
 		# Try adding to each group
-		for i in range(n):
+		for i in xrange(n):
 			iwork = workfun(work[i],d)
 			icost = costfun(work[:i]+[iwork]+work[i+1:])
 			if i == 0 or icost < best[2]: best = (i,iwork,icost)
@@ -1241,7 +1243,7 @@ def uncat(a, lens):
 	and lens = [len(x) for x in b], then uncat(a,lens) returns
 	b."""
 	cum = cumsum(lens, endpoint=True)
-	return [a[cum[i]:cum[i+1]] for i in range(len(lens))]
+	return [a[cum[i]:cum[i+1]] for i in xrange(len(lens))]
 
 def ang2rect(angs, zenith=False, axis=0):
 	"""Convert a set of angles [{phi,theta},...] to cartesian
@@ -1393,12 +1395,12 @@ def find_equal_groups(a, tol=0):
 	inds = np.argsort(a[:,0])
 	done = np.full(n, False, dtype=bool)
 	res = []
-	for i in range(n):
+	for i in xrange(n):
 		if done[i]: continue
 		xi = inds[i]
 		res.append([xi])
 		done[i] = True
-		for j in range(i+1,n):
+		for j in xrange(i+1,n):
 			if done[j]: continue
 			xj = inds[j]
 			if calc_diff(a[xj,0], a[xi,0]) > tol:

--- a/pixell/utils.py
+++ b/pixell/utils.py
@@ -439,7 +439,7 @@ def equal_split(weights, nbin):
 	weight in each bin is as close to equal as possible.
 	Returns a list of indices for each bin."""
 	inds = np.argsort(weights)[::-1]
-	bins = [[] for b in xrange(nbin)]
+	bins = [[] for b in range(nbin)]
 	bw   = np.zeros([nbin])
 	for i in inds:
 		j = np.argmin(bw)
@@ -543,12 +543,12 @@ def range_union(a, mapping=False):
 	rmap = np.zeros(n,dtype=int)-1
 	b    = []
 	# i will point at the first unprocessed range
-	for i in xrange(n):
+	for i in range(n):
 		if rmap[inds[i]] >= 0: continue
 		rmap[inds[i]] = len(b)
 		start, end = a[inds[i]]
 		# loop through every unprocessed range in range
-		for j in xrange(i+1,n):
+		for j in range(i+1,n):
 			if rmap[inds[j]] >= 0: continue
 			if a[inds[j],0] > end: break
 			# This range overlaps, so register it and merge
@@ -660,19 +660,19 @@ def greedy_split(data, n=2, costfun=max, workfun=lambda w,x: x if w is None else
 	# Sort data based on standalone costs
 	costs = []
 	nowork = workfun(None,None)
-	work = [nowork for i in xrange(n)]
+	work = [nowork for i in range(n)]
 	for d in data:
 		work[0] = workfun(nowork,d)
 		costs.append(costfun(work))
 	order = np.argsort(costs)[::-1]
 	# Build groups using greedy algorithm
-	groups = [[] for i in xrange(n)]
-	work   = [nowork for i in xrange(n)]
+	groups = [[] for i in range(n)]
+	work   = [nowork for i in range(n)]
 	cost   = costfun(work)
 	for di in order:
 		d = data[di]
 		# Try adding to each group
-		for i in xrange(n):
+		for i in range(n):
 			iwork = workfun(work[i],d)
 			icost = costfun(work[:i]+[iwork]+work[i+1:])
 			if i == 0 or icost < best[2]: best = (i,iwork,icost)
@@ -1241,7 +1241,7 @@ def uncat(a, lens):
 	and lens = [len(x) for x in b], then uncat(a,lens) returns
 	b."""
 	cum = cumsum(lens, endpoint=True)
-	return [a[cum[i]:cum[i+1]] for i in xrange(len(lens))]
+	return [a[cum[i]:cum[i+1]] for i in range(len(lens))]
 
 def ang2rect(angs, zenith=False, axis=0):
 	"""Convert a set of angles [{phi,theta},...] to cartesian
@@ -1393,12 +1393,12 @@ def find_equal_groups(a, tol=0):
 	inds = np.argsort(a[:,0])
 	done = np.full(n, False, dtype=bool)
 	res = []
-	for i in xrange(n):
+	for i in range(n):
 		if done[i]: continue
 		xi = inds[i]
 		res.append([xi])
 		done[i] = True
-		for j in xrange(i+1,n):
+		for j in range(i+1,n):
 			if done[j]: continue
 			xj = inds[j]
 			if calc_diff(a[xj,0], a[xi,0]) > tol:


### PR DESCRIPTION
This PR adds a routine enmap.cutsky_geometry that returns  a shape,wcs pair for a sky wrapped geometry that has a minimum and maxmimum declination. It also changes some `xrange` to `range` for Python 3 compatibility.