### PR TITLE
More enmap docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,9 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode','sphinx.ext.napoleon']
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
+# Present auto-documented members in source order (rather than alphabetical).
+autodoc_member_order = 'bysource'
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,8 +1,8 @@
 .. _ReferencePage:
 
-=====
+=========
 Reference
-=====
+=========
 
 .. sectnum:: :start: 2
 
@@ -10,68 +10,68 @@ Reference
 See :ref:`UsagePage` for how to use these functions for common map manipulation tasks.
 
 enmap - General map manipulation
------
+--------------------------------
 
 .. automodule:: pixell.enmap
    :members:    
 
 fft - Fourier transforms
------
+------------------------
 
 .. automodule:: pixell.fft
    :members:    
 
 curvedsky - Curved-sky harmonic transforms
------
+------------------------------------------
 
 .. automodule:: pixell.curvedsky
    :members:          
 
 utils - General utilities
------
+-------------------------
 
 .. automodule:: pixell.utils
    :members:    
    
 reproject - Map reprojection
------
+----------------------------
       
 .. automodule:: pixell.reproject
    :members:    
 
 resample - Map resampling
------
+-------------------------
       
 .. automodule:: pixell.resample
    :members:
       
 lensing - Lensing
------
+-----------------
       
 .. automodule:: pixell.lensing
    :members:
 
 interpol - Interpolation
------
+------------------------
       
 .. automodule:: pixell.interpol
    :members:
       
 coordinates - Coordinate Transformation
------
+---------------------------------------
       
 .. automodule:: pixell.coordinates
    :members:
       
 
 wcsutils - World Coordinate Sytem utilities
------
+-------------------------------------------
 
 .. automodule:: pixell.wcsutils
    :members:          
 
 powspec - CMB power spectra utilities
------
+-------------------------------------
 
 .. automodule:: pixell.powspec
    :members:          

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -14,65 +14,74 @@ enmap - General map manipulation
 
 .. automodule:: pixell.enmap
    :members:    
+   :undoc-members:
 
 fft - Fourier transforms
 ------------------------
 
 .. automodule:: pixell.fft
    :members:    
+   :undoc-members:
 
 curvedsky - Curved-sky harmonic transforms
 ------------------------------------------
 
 .. automodule:: pixell.curvedsky
    :members:          
+   :undoc-members:
 
 utils - General utilities
 -------------------------
 
 .. automodule:: pixell.utils
    :members:    
+   :undoc-members:
    
 reproject - Map reprojection
 ----------------------------
-      
 .. automodule:: pixell.reproject
    :members:    
+   :undoc-members:
 
 resample - Map resampling
 -------------------------
       
 .. automodule:: pixell.resample
    :members:
+   :undoc-members:
       
 lensing - Lensing
 -----------------
       
 .. automodule:: pixell.lensing
    :members:
+   :undoc-members:
 
 interpol - Interpolation
 ------------------------
       
 .. automodule:: pixell.interpol
    :members:
+   :undoc-members:
       
 coordinates - Coordinate Transformation
 ---------------------------------------
       
 .. automodule:: pixell.coordinates
    :members:
-      
+   :undoc-members:
 
 wcsutils - World Coordinate Sytem utilities
 -------------------------------------------
 
 .. automodule:: pixell.wcsutils
    :members:          
+   :undoc-members:
 
 powspec - CMB power spectra utilities
 -------------------------------------
 
 .. automodule:: pixell.powspec
    :members:          
+   :undoc-members:
       

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -6,11 +6,60 @@ Usage
 
 .. sectnum:: :start: 1
 
-Any map can be completely specified by two objects, a numpy array (of at least two dimensions) whose two trailing dimensions correspond to two coordinate axes of the map, and a ``wcs`` object that specifies the World Coordinate System. The latter specifies the correspondence between pixels and physical sky coordinates. This library allows for the manipulation of an object ``ndmap``, which has all the properties of numpy arrays but is in addition enriched by the ``wcs`` object (specifically an instantiation of Astropy's ``astropy.wcs.wcs.WCS`` object). The ``shape`` of the numpy array and the ``wcs`` completely specifies the geometry and footprint of a map of the sky.
+The ``ndmap`` object
+--------------------
 
-All ``ndmap`` s must have at least two dimensions. The trailing two axes are interpreted as the Y (typically, declination) and X (typically, right ascension) axes. Maps can have arbitrary number of leading dimensions, but many of ``pixell``' CMB-related tools interpret a 3D array of shape ``(ncomp,Ny,Nx)`` to consist of three ``Ny`` x ``Nx`` maps of intensity, polarization Q and U Stokes parameters in that order.
+Any map can be completely specified by two objects, a numpy array (of
+at least two dimensions) whose two trailing dimensions correspond to
+two coordinate axes of the map, and a ``wcs`` object that specifies
+the World Coordinate System. The latter specifies the correspondence
+between pixels and physical sky coordinates. This library allows for
+the manipulation of an object ``ndmap``, which has all the properties
+of numpy arrays but is in addition enriched by the ``wcs`` object
+(specifically an instantiation of Astropy's ``astropy.wcs.wcs.WCS``
+object). The combination of the ``shape`` of the numpy array and the
+``wcs`` completely specifies the footprint of a map of the sky, and is
+called the ``geometry``.
+
+An ``ndmap`` must have at least two dimensions. The two right-most
+axes represent celestial coordinates (typically Declination and Right
+Ascension).  Maps can have arbitrary number of leading dimensions, but
+many of the ``pixell`` CMB-related tools interpret 3D arrays with
+shape ``(ncomp,Ny,Nx)`` as representing ``Ny`` x ``Nx`` maps of
+intensity, polarization Q and U Stokes parameters, in that order.
+
+In the two celestial axes, the "first" pixel (index [0,0]) corresponds
+to the lower left-hand corner of the map, as it would be displayed on
+a screen or printed page.  The first index represents the row,
+parallel to the Cartesian Y-axis, typically associated with increasing
+Declination.  The second index represents the column, parallel to the
+Cartesian X-axis, typically associated with decreasing Right
+Ascension.
 
 TODO: I've listed below common operations that would be useful to demonstrate here.  Finish this! (See :ref:`ReferencePage` for a dump of all member functions)
+
+Creating an ``ndmap``
+---------------------
+
+To create an empty ``ndmap``, call the ``enmap.zeros`` or
+``enmap.empty`` functions and specify the map shape as well as the
+pixelization information (the WCS).  Here is a basic example:
+
+.. code-block:: python
+
+   >>> from pixell import enmap, utils
+   >>> box = np.array([[-5,10],[5,-10]]) * utils.degree
+   >>> shape,wcs = enmap.geometry(pos=box,res=0.5 * utils.arcmin,proj='car')
+   >>> imap = enmap.zeros((3,) + shape, wcs=wcs)
+
+In this example we are requesting a pixelization that spans from -5
+to +5 in declination, and +10 to -10 in Right Ascension.  Note that we
+need to specify the Right Ascension coordinates in decreasing order,
+or the map, when we display it with pixel [0,0] in the lower left-hand
+corner, will not have the usual astronomical orientation.
+
+For more information on designing the geometry, see
+:ref:`geometry-section`.
 
 Maps are extensions of ``numpy`` arrays
 ---------------------------------------
@@ -226,6 +275,9 @@ A filter can be applied to a map in three steps:
 2. Fourier transform the map ``imap`` to ``kmap``
 3. multiply the filter and k-map
 4. inverse Fourier transform the result
+
+
+.. _geometry-section:
 
 Building a map geometry
 ----------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -290,11 +290,12 @@ You can create a geometry if you know what its bounding box and pixel size are:
 .. code-block:: python
 
 		>>> from pixell import enmap, utils
-		>>> box = np.array([[-5,-5],[5,5]]) * utils.degree
+		>>> box = np.array([[-5,10],[5,-10]]) * utils.degree
 		>>> shape,wcs = enmap.geometry(pos=box,res=0.5 * utils.arcmin,proj='car')
 
-This creates a CAR geometry centered on RA=0d,DEC=0d with a width and height of
-10 degrees and a pixel size of 0.5 arcminutes.
+This creates a CAR geometry centered on RA=0d,DEC=0d with a width of
+20 degrees, a height of 10 degrees, and a pixel size of 0.5
+arcminutes.
 
 Full sky
 ~~~~~~~~

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -276,12 +276,28 @@ def enmap(arr, wcs=None, dtype=None, copy=True):
 	return ndmap(arr, wcs)
 
 def empty(shape, wcs=None, dtype=None):
+	"""
+	Return an enmap with entries uninitialized (like numpy.empty).
+	"""
 	return enmap(np.empty(shape, dtype=dtype), wcs, copy=False)
+
 def zeros(shape, wcs=None, dtype=None):
+	"""
+	Return an enmap with entries initialized to zero (like
+	numpy.zeros).
+	"""
 	return enmap(np.zeros(shape, dtype=dtype), wcs, copy=False)
+
 def ones(shape, wcs=None, dtype=None):
+	"""
+	Return an enmap with entries initialized to one (like numpy.ones).
+	"""
 	return enmap(np.ones(shape, dtype=dtype), wcs, copy=False)
+
 def full(shape, wcs, val, dtype=None):
+	"""
+	Return an enmap with entries initialized to val (like numpy.full).
+	"""
 	return enmap(np.full(shape, val, dtype=dtype), wcs, copy=False)
 
 def posmap(shape, wcs, safe=True, corner=False, separable=False, dtype=np.float64, bsize=1e6):


### PR DESCRIPTION
1. Add a section on creating enmaps; explain RA vs. Dec axes a little more.
2. Add basic documentation to enmap.py creating functions (empty,zeros,ones,full).
3. In the reference section, include all members (even undocumented ones) and list them in source order rather than alphabetical order.
