### PR TITLE
Fix zenithal ref

### DIFF
--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -879,7 +879,7 @@ def geometry(pos, res=None, shape=None, proj="car", deg=False, pre=(), force=Fal
 	resulting bounding box can differ by a fraction of a pixel from the one requested.
 	To force the geometry to exactly match the bounding box provided you can pass force=True.
 	It is also possible to manually choose the reference point via the ref argument, which
-	must be a ra,dec (note the order) coordinate pair, in degrees."""
+	must be a dec,ra coordinate pair (in radians)."""
 	# We use radians by default, while wcslib uses degrees, so need to rescale.
 	# The exception is when we are using a plain, non-spherical wcs, in which case
 	# both are unitless. So undo the scaling in this case.
@@ -889,6 +889,12 @@ def geometry(pos, res=None, shape=None, proj="car", deg=False, pre=(), force=Fal
 	if res is not None: res = np.asarray(res)*scale
 	# Apply a standard reference points unless one is manually specified, or we
 	# want to force the bounding box to exactly match the input.
+	try:
+		# if it's a (dec,ra) tuple in radians, make it (ra,dec) in degrees.
+		ref = (ref[1] * scale, ref[0] * scale)
+		assert(len(ref) == 2)
+	except (TypeError, ValueError):
+		pass
 	if ref is None and not force: ref = "standard"
 	wcs = wcsutils.build(pos, res, shape, rowmajor=True, system=proj, ref=ref, **kwargs)
 	if shape is None:

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -878,8 +878,8 @@ def geometry(pos, res=None, shape=None, proj="car", deg=False, pre=(), force=Fal
 	spherical harmonics transform ring weights. The cost of this tweaking is that the
 	resulting bounding box can differ by a fraction of a pixel from the one requested.
 	To force the geometry to exactly match the bounding box provided you can pass force=True.
-	It is also possible to manually choose the reference pixel via the ref argument, which
-	must be a dec,ra coordinate pair."""
+	It is also possible to manually choose the reference point via the ref argument, which
+	must be a ra,dec (note the order) coordinate pair, in degrees."""
 	# We use radians by default, while wcslib uses degrees, so need to rescale.
 	# The exception is when we are using a plain, non-spherical wcs, in which case
 	# both are unitless. So undo the scaling in this case.

--- a/pixell/wcsutils.py
+++ b/pixell/wcsutils.py
@@ -229,18 +229,11 @@ def finalize(w, pos, res, shape, ref=None):
 		off = w.wcs_world2pix(pos[0,None],0)[0]+0.5
 		w.wcs.crpix -= off
 	if ref is not None:
-		# Tweak wcs so that crval is an integer number of pixels
-		# away from ref. We do that by constructing a new wcs centered
-		# on ref, measuring the pixel coordinates of crval in this system
-		# and truncating it to a whole pixel number.
-		wtmp = w.deepcopy()
-		wtmp.wcs.crpix = (1,1)
-		wtmp.wcs.crval = ref
-		w.wcs.crval = wtmp.wcs_pix2world(np.round(wtmp.wcs_world2pix(w.wcs.crval[None],1)),1)[0]
-		# We can then simply round the crpix to the closest integer. Together with the
-		# previous operation, this will displace us by around 1 pixel, which is the
-		# cost one has to pay for this realignment.
-		w.wcs.crpix = np.round(w.wcs.crpix)
+		# Tweak wcs so that crval is an integer number of
+		# pixels away from ref.  This is most straight-forward
+		# if one simply adjusts crpix.
+		off = (w.wcs_world2pix(np.asarray(ref)[None], 1)[0] + 0.5) % 1 - 0.5
+		w.wcs.crpix -= off
 	return w
 
 def angdist(lon1,lat1,lon2,lat2):

--- a/pixell/wcsutils.py
+++ b/pixell/wcsutils.py
@@ -143,7 +143,7 @@ def zea(pos, res=None, shape=None, rowmajor=False, ref=None):
 	w = WCS(naxis=2)
 	w.wcs.ctype = ["RA---ZEA", "DEC--ZEA"]
 	w.wcs.crval = mid
-	if ref is "standard": ref = None
+	w, ref = _apply_zenithal_ref(w, ref)
 	return finalize(w, pos, res, shape, ref=ref)
 
 # The airy distribution is a bit different, since is needs to
@@ -160,16 +160,16 @@ def air(pos, res=None, shape=None, rowmajor=False, rad=None, ref=None):
 	w = WCS(naxis=2)
 	w.wcs.ctype = ["RA---AIR","DEC--AIR"]
 	w.wcs.set_pv([(2,1,90-rad)])
-	if ref is "standard": ref = None
+	w, ref = _apply_zenithal_ref(w, ref)
 	return finalize(w, pos, res, shape, ref=ref)
 
 def tan(pos, res=None, shape=None, rowmajor=False, ref=None):
-	"""Set up a plate carree system. See the build function for details."""
+	"""Set up a gnomonic (tangent plane) system. See the build function for details."""
 	pos, res, shape, mid = validate(pos, res, shape, rowmajor)
 	w = WCS(naxis=2)
 	w.wcs.ctype = ["RA---TAN", "DEC--TAN"]
-	w.wcs.crval = np.array([mid[0],0])
-	if ref is "standard": ref = None
+	w.wcs.crval = mid
+	w, ref = _apply_zenithal_ref(w, ref)
 	return finalize(w, pos, res, shape, ref=ref)
 
 systems = {"car": car, "cea": cea, "air": air, "zea": zea, "tan": tan, "gnom": tan, "plain": plain }
@@ -235,6 +235,21 @@ def finalize(w, pos, res, shape, ref=None):
 		off = (w.wcs_world2pix(np.asarray(ref)[None], 1)[0] + 0.5) % 1 - 0.5
 		w.wcs.crpix -= off
 	return w
+
+def _apply_zenithal_ref(w, ref):
+        """Input is a wcs w and ref is a position (dec,ra) or a special value
+        (None, 'standard').  Returns tuple (w, ref_out).  If ref is a
+        position, it is copied into w.wcs.crval and ref_out=ref.
+        Otherwise, w is unmodified and ref_out=w.wcs.crval.
+
+        """
+        if isinstance(ref, str) and ref == 'standard':
+                ref = None
+        if ref is None:
+                ref = w.wcs.crval
+        else:
+                w.wcs.crval = ref
+        return w, ref
 
 def angdist(lon1,lat1,lon2,lat2):
 	return np.arccos(np.cos(lat1)*np.cos(lat2)*(np.cos(lon1)*np.cos(lon2)+np.sin(lon1)*np.sin(lon2))+np.sin(lat1)*np.sin(lat2))

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -46,7 +46,7 @@ class GeometryTests(unittest.TestCase):
             shape, wcs = enmap.geometry(pos=patch.pos(),
                                         res=DELT*DEG,
                                         proj='cea',
-                                        ref=(ra1,0))
+                                        ref=(0, ra1*DEG))
             ref = np.array([[ra1,0]])
             ref_pix = wcs.wcs_world2pix(ref, 0)
             assert(np.all(is_centered(ref_pix)))
@@ -55,19 +55,20 @@ class GeometryTests(unittest.TestCase):
         DELT = 0.05
         patch0 = Patch.centered_at(308., -38., 1.+DELT, 1.+DELT)
         patch1 = Patch.centered_at(309., -39., 1.+DELT, 1.+DELT)
-        ref = patch0.center()[::-1]
+        ref = patch0.center()   # (dec,ra) in degrees.
         for proj in ['tan', 'zea', 'air']:
             print('Checking reference tracking of "%s"...' % proj)
             shape0, wcs0 = enmap.geometry(pos=patch0.pos(),
                                           res=DELT*utils.degree,
                                           proj=proj,
-                                          ref=ref)
+                                          ref=ref*DEG)
             shape1, wcs1 = enmap.geometry(pos=patch1.pos(),
                                           res=DELT*utils.degree,
                                           proj=proj,
-                                          ref=ref)
-            pix0 = wcs0.wcs_world2pix(ref[None],0)
-            pix1 = wcs1.wcs_world2pix(ref[None],0)
+                                          ref=ref*DEG)
+            # Note world2pix wants [(ra,dec)], in degrees...
+            pix0 = wcs0.wcs_world2pix(ref[::-1][None],0)
+            pix1 = wcs1.wcs_world2pix(ref[::-1][None],0)
             print(shape0,wcs0,pix0)
             assert(np.all(is_centered(pix0)))
             assert(np.all(is_centered(pix1)))

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -1,0 +1,55 @@
+import unittest
+
+from pixell import enmap, wcsutils, utils
+DEG = utils.degree
+import numpy as np
+
+def is_centered(pixel_index, rtol=1e-6):
+    """Returns element-by-element True if pixel_index is sufficiently
+    close to integer-valued."""
+    frac = (np.asarray(pixel_index) + 0.5) % 1.0 - 0.5
+    return np.isclose(frac, 0., rtol=rtol)
+
+class Patch:
+    ra_range = None  #! Right Ascension; left side, right side.
+    dec_range = None #! Declination; bottom, top.
+    @classmethod
+    def centered_at(cls, ra0, dec0, width, height):
+        self = cls()
+        self.ra_range = (ra0+width/2, ra0-width/2)
+        self.dec_range = (dec0-height/2, dec0+height/2)
+        return self
+
+    def pos(self):
+        return np.array([[self.dec_range[0], self.ra_range[0]],
+                         [self.dec_range[1], self.ra_range[1]]]) * DEG
+    def extent(self, delta_ra = 0., delta_dec = 0.):
+        return [self.ra_range[0]  + delta_ra /2, self.ra_range[1]  - delta_ra /2,
+                self.dec_range[0] - delta_dec/2, self.dec_range[1] + delta_dec/2]
+    def center(self):
+        return 0.5 * np.array([(self.dec_range[0] + self.dec_range[1]),
+                               (self.ra_range[0] + self.ra_range[1])])
+
+
+class GeometryTests(unittest.TestCase):
+
+    def test_reference(self):
+        """Test that WCS are properly adjusted, on request, to put a reference
+        pixel at integer pixel number.
+
+        """
+        DELT = 0.1
+        # Note we're adding a half-pixel margin to stay away from rounding cut.
+        patch = Patch.centered_at(-52., -38., 12. + DELT, 12.0 + DELT)
+        # Test a few reference RAs.
+        for ra1 in [0., 0.001, 90.999, 91.101, 120., 179.9, 180.0, 180.1, 270.]:
+            shape, wcs = enmap.geometry(pos=patch.pos(),
+                                        res=DELT*DEG,
+                                        proj='cea',
+                                        ref=(ra1,0))
+            ref = np.array([[ra1,0]])
+            ref_pix = wcs.wcs_world2pix(ref, 0)
+            assert(np.all(is_centered(ref_pix)))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -51,5 +51,26 @@ class GeometryTests(unittest.TestCase):
             ref_pix = wcs.wcs_world2pix(ref, 0)
             assert(np.all(is_centered(ref_pix)))
 
+    def test_zenithal(self):
+        DELT = 0.05
+        patch0 = Patch.centered_at(308., -38., 1.+DELT, 1.+DELT)
+        patch1 = Patch.centered_at(309., -39., 1.+DELT, 1.+DELT)
+        ref = patch0.center()[::-1]
+        for proj in ['tan', 'zea', 'air']:
+            print('Checking reference tracking of "%s"...' % proj)
+            shape0, wcs0 = enmap.geometry(pos=patch0.pos(),
+                                          res=DELT*utils.degree,
+                                          proj=proj,
+                                          ref=ref)
+            shape1, wcs1 = enmap.geometry(pos=patch1.pos(),
+                                          res=DELT*utils.degree,
+                                          proj=proj,
+                                          ref=ref)
+            pix0 = wcs0.wcs_world2pix(ref[None],0)
+            pix1 = wcs1.wcs_world2pix(ref[None],0)
+            print(shape0,wcs0,pix0)
+            assert(np.all(is_centered(pix0)))
+            assert(np.all(is_centered(pix1)))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The main purpose of this PR is to properly set the reference point in Zenithal projections.  The code that handled "ref" was ok for cylindrical projections but does not generalize to, e.g., TAN.
