### PR TITLE
enmap: fix area and fullsky_geometry functions.

### DIFF
--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -16,8 +16,8 @@ class Patch:
     @classmethod
     def centered_at(cls, ra0, dec0, width, height):
         self = cls()
-        self.ra_range = (ra0+width/2, ra0-width/2)
-        self.dec_range = (dec0-height/2, dec0+height/2)
+        self.ra_range = np.array((ra0+width/2, ra0-width/2))
+        self.dec_range = np.array((dec0-height/2, dec0+height/2))
         return self
 
     def pos(self):
@@ -72,6 +72,47 @@ class GeometryTests(unittest.TestCase):
             print(shape0,wcs0,pix0)
             assert(np.all(is_centered(pix0)))
             assert(np.all(is_centered(pix1)))
+
+    def test_full_sky(self):
+        """Test that fullsky_geometry returns sensible objects.
+
+        Or at least the objects that we considered sensible when we
+        wrote this test.
+
+        """
+        shape, w = enmap.fullsky_geometry(res=0.01*DEG, proj='car')
+        ny, nx = shape
+        for delta, expect_nans in [(0., False), (.001, True)]:
+            for ix in [-0.5-delta,nx-0.5+delta]:
+                for iy in [0-delta, ny-1+delta]:
+                    c = w.wcs_pix2world([(ix,iy)], 0)
+                    #print(ix,iy,c)
+                    assert np.any(np.isnan(c)) == expect_nans
+
+
+    def test_area(self):
+        """Test that map area is computed accurately."""
+        test_patches = []
+        # Small CAR patch
+        DELT = 0.01
+        patch = Patch.centered_at(-52., -38., 12. + DELT, 12.0 + DELT)
+        shape, w = enmap.geometry(pos=patch.pos(),
+                                  res=DELT*DEG,
+                                  proj='car',
+                                  ref=(0, 0))
+        exact_area = (np.dot(patch.ra_range*DEG, [-1,1]) *
+                      np.dot(np.sin(patch.dec_range*DEG), [1,-1]))
+
+        test_patches.append((shape, w, exact_area))
+        # Full sky CAR patch
+        shape, w = enmap.fullsky_geometry(res=0.01*DEG, proj='car')
+        exact_area = 4*np.pi
+        test_patches.append((shape, w, exact_area))
+
+        for shape, w, exact_area in test_patches:
+            ratio = enmap.area(shape, w)/exact_area
+            print(ratio)
+            assert(abs(ratio-1) < 1e-8)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_pixell.py
+++ b/tests/test_pixell.py
@@ -108,7 +108,7 @@ class PixelTests(unittest.TestCase):
         test_res_arcmin = 0.5
         shape,wcs = enmap.fullsky_geometry(res=np.deg2rad(test_res_arcmin/60.),proj='car')
         assert shape[0]==21601 and shape[1]==43200
-        assert 50000 < (enmap.area(shape,wcs)*(180./np.pi)**2.) < 51000
+        assert abs(enmap.area(shape,wcs) - 4*np.pi) < 1e-6
 
     def test_pixels(self):
         """Runs reference pixel and mean-square comparisons on extracts from randomly generated


### PR DESCRIPTION
Addresses #70 .

The area() function now computes area precisely and quickly in a broad
class of geometries.  The fullsky_geometry function is more careful
with the RA axis native coordinate system branch cut; now all pixels
in the grid (that are not at the poles) have valid coordinates (across
their entire areas).
