### PR TITLE
Support for plain/Cartesian (true flat-sky) coordinate systems

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -12,7 +12,10 @@ The ``ndmap`` object
 The ``pixell`` library supports manipulation of sky maps that are
 represented as 2-dimensional grids of rectangular pixels.  The
 supported projection and pixelization schemes are a subset of the
-schemes supported by FITS conventions.
+schemes supported by FITS conventions. In addition, we provide
+support for a `plain' coordinate system, corresponding to a
+Cartesian plane with identically shaped pixels (useful for true
+flat-sky calculations).
 
 In ``pixell``, a map is encapsulated in an ``ndmap``, which combines
 two objects: a numpy array (of at least two dimensions) whose two

--- a/pixell/curvedsky.py
+++ b/pixell/curvedsky.py
@@ -406,7 +406,7 @@ def map2minfo(m):
 	return sharp.map_info(theta, nphi, phi0)
 
 def match_predefined_minfo(m, rtol=None, atol=None):
-	"""Given an enmapwith constant-latitude rows and constant longitude
+	"""Given an enmap with constant-latitude rows and constant longitude
 	intervals, return the libsharp predefined minfo with ringweights that's
 	the closest match to our pixelization."""
 	if rtol is None: rtol = 1e-3*utils.arcmin

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -229,8 +229,7 @@ def scale_geometry(shape, wcs, scale):
 	return oshape, owcs
 
 def get_unit(wcs):
-	if wcsutils.is_plain(wcs): return 1
-	else: return utils.degree
+	return utils.degree
 
 class Geometry:
 	def __init__(self, shape, wcs=None):
@@ -277,7 +276,7 @@ def box(shape, wcs, npoint=10, corner=True):
 	if corner: pix -= 0.5
 	coords = wcsutils.nobcheck(wcs).wcs_pix2world(pix[1],pix[0],0)[::-1]
 	if wcsutils.is_plain(wcs):
-		return np.array(coords).T[[0,-1]]
+		return np.array(coords).T[[0,-1]]*utils.degree
 	else:
 		return utils.unwind(np.array(coords)*utils.degree).T[[0,-1]]
 
@@ -493,7 +492,8 @@ def extract_pixbox(map, pixbox, omap=None, wrap="auto", op=lambda a,b:b, cval=0,
 	nphi = utils.nint(360/np.abs(iwcs.wcs.cdelt[0]))
 	# If our map is wider than the wrapping length, assume we're a lower-spin field
 	nphi *= (nphi+map.shape[-1]-1)//nphi
-	if wrap is "auto": wrap = [0,nphi]
+	if wrap is "auto":
+		wrap = [0,0] if wcsutils.is_plain(wcs) else [0,nphi]
 	else: wrap = np.zeros(2,int)+wrap
 	for ibox, obox in utils.sbox_wrap(pixbox.T, wrap=wrap, cap=map.shape[-2:]):
 		islice = utils.sbox2slice(ibox)
@@ -520,6 +520,10 @@ def neighborhood_pixboxes(shape, wcs, poss, r):
 	"""Given a set of positions poss[npos,2] in radians and a distance r in radians,
 	return pixboxes[npos][{from,to},{y,x}] corresponding to the regions within a
 	distance of r from each entry in poss."""
+	if wcsutils.is_plain(wcs):
+		rpix = r/pixsize(shape, wcs)
+		centers = sky2pix(poss.T).T
+		return np.moveaxis([centers-rpix,center+rpix+1],0,1)
 	poss = np.asarray(poss)
 	res  = np.zeros([len(poss),2,2])
 	for i, pos in enumerate(poss):
@@ -808,6 +812,11 @@ def pixshapemap(shape, wcs, bsize=1000):
 	"""Returns the physical width and heigh of each pixel in the map in radians.
 	Heavy for big maps. Much faster approaches are possible for known pixelizations."""
 	res    = zeros((2,)+shape[-2:], wcs)
+	if wcsutils.is_plain(wcs):
+		cdelt = wcs.wcs.cdelt
+		res[0] = wcs.wcs.cdelt[1]*utils.degree
+		res[1] = wcs.wcs.cdelt[0]*utils.degree
+		return np.abs(res)
 	# Loop over blocks in y to reduce memory usage
 	for i1 in range(0, shape[-2], bsize):
 		i2 = min(i1+bsize, shape[-2])
@@ -868,6 +877,7 @@ def modrmap(shape, wcs, ref="center", safe=True, corner=False):
 		if ref=="center": ref = center(shape,wcs)
 		else:             raise ValueError
 	ref = np.array(ref)[:,None,None]
+	if wcsutils.is_plain(wcs): return np.sum((slmap-ref)**2,0)**0.5
 	return ndmap(utils.angdist(slmap[::-1],ref[::-1],zenith=False),wcs)
 
 
@@ -1063,7 +1073,6 @@ def geometry(pos, res=None, shape=None, proj="car", deg=False, pre=(), force=Fal
 	# The exception is when we are using a plain, non-spherical wcs, in which case
 	# both are unitless. So undo the scaling in this case.
 	scale = 1 if deg else 1/utils.degree
-	if proj == "plain": scale *= utils.degree
 	pos = np.asarray(pos)*scale
 	if res is not None: res = np.asarray(res)*scale
 	# Apply a standard reference points unless one is manually specified, or we
@@ -1140,7 +1149,7 @@ def band_geometry(dec_cut,res=None, shape=None, dims=(), proj="car"):
 def create_wcs(shape, box=None, proj="cea"):
 	if box is None:
 		box = np.array([[-1,-1],[1,1]])*0.5*10
-		if proj != "plain": box *= utils.degree
+		box *= utils.degree
 	return wcsutils.build(box, shape=shape, rowmajor=True, system=proj)
 
 def spec2flat(shape, wcs, cov, exp=1.0, mode="constant", oversample=1, smooth="auto"):
@@ -1338,6 +1347,7 @@ def distance_from(shape, wcs, points, omap=None, odomains=None, domains=False, m
 	and domains to -1. This can be used to speed up the calculation when one only cares
 	about nearby areas."""
 	from pixell import distances
+	if wcsutils.is_plain(wcs): warnings.warn("Distance functions are not tested on plain coordinate systems.")
 	if omap is None: omap = empty(shape[-2:], wcs)
 	if domains and odomains is None: odomains = empty(shape[-2:], wcs, np.int32)
 	if wcsutils.is_cyl(wcs):

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -276,9 +276,9 @@ def box(shape, wcs, npoint=10, corner=True):
 	if corner: pix -= 0.5
 	coords = wcsutils.nobcheck(wcs).wcs_pix2world(pix[1],pix[0],0)[::-1]
 	if wcsutils.is_plain(wcs):
-		return np.array(coords).T[[0,-1]]*utils.degree
+		return np.array(coords).T[[0,-1]]*get_unit(wcs)
 	else:
-		return utils.unwind(np.array(coords)*utils.degree).T[[0,-1]]
+		return utils.unwind(np.array(coords)*get_unit(wcs)).T[[0,-1]]
 
 def enmap(arr, wcs=None, dtype=None, copy=True):
 	"""Construct an ndmap from data.

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -814,8 +814,8 @@ def pixshapemap(shape, wcs, bsize=1000):
 	res    = zeros((2,)+shape[-2:], wcs)
 	if wcsutils.is_plain(wcs):
 		cdelt = wcs.wcs.cdelt
-		res[0] = wcs.wcs.cdelt[1]*utils.degree
-		res[1] = wcs.wcs.cdelt[0]*utils.degree
+		res[0] = wcs.wcs.cdelt[1]*get_unit(wcs)
+		res[1] = wcs.wcs.cdelt[0]*get_unit(wcs)
 		return np.abs(res)
 	# Loop over blocks in y to reduce memory usage
 	for i1 in range(0, shape[-2], bsize):

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -493,7 +493,7 @@ def extract_pixbox(map, pixbox, omap=None, wrap="auto", op=lambda a,b:b, cval=0,
 	# If our map is wider than the wrapping length, assume we're a lower-spin field
 	nphi *= (nphi+map.shape[-1]-1)//nphi
 	if wrap is "auto":
-		wrap = [0,0] if wcsutils.is_plain(wcs) else [0,nphi]
+		wrap = [0,0] if wcsutils.is_plain(iwcs) else [0,nphi]
 	else: wrap = np.zeros(2,int)+wrap
 	for ibox, obox in utils.sbox_wrap(pixbox.T, wrap=wrap, cap=map.shape[-2:]):
 		islice = utils.sbox2slice(ibox)

--- a/pixell/wcsutils.py
+++ b/pixell/wcsutils.py
@@ -56,6 +56,7 @@ def describe(wcs):
 	return "%s:{%s}" % (sys, fields)
 # Add this to all WCSes in this class
 WCS.__repr__ = describe
+WCS.__str__ = describe
 
 def equal(wcs1, wcs2):
 	return repr(wcs1.to_header()) == repr(wcs2.to_header())

--- a/tests/test_pixell.py
+++ b/tests/test_pixell.py
@@ -237,6 +237,21 @@ class PixelTests(unittest.TestCase):
         assert np.all(np.isclose(rmap[1],rmap2[1],atol=1e0))
         assert np.all(np.isclose(rmap[2],rmap2[2],atol=1e0))
 
+    def test_plain_wcs(self):
+        # Test area and box for a small Cartesian geometry
+        shape,wcs = enmap.geometry(res=np.deg2rad(1./60.),shape=(600,600),pos=(0,0),proj='plain')
+        box = np.rad2deg(enmap.box(shape,wcs))
+        area = np.rad2deg(np.rad2deg(enmap.area(shape,wcs)))
+        assert np.all(np.isclose(box,np.array([[-5,-5],[5,5]])))
+        assert np.isclose(area,100.)
+
+        # and for an artifical Cartesian geometry with area>4pi
+        shape,wcs = enmap.geometry(res=np.deg2rad(10),shape=(100,100),pos=(0,0),proj='plain')
+        box = np.rad2deg(enmap.box(shape,wcs))
+        area = np.rad2deg(np.rad2deg(enmap.area(shape,wcs)))
+        assert np.all(np.isclose(box,np.array([[-500,-500],[500,500]])))
+        assert np.isclose(area,1000000)
+                                
         
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes #79 . It extends the functionality of the "plain" wcs type preventing it from throwing out its units, and it provides drop in replacements for some enmap functions for the simpler plain/Cartesian system.