### PR TITLE
Handle pixel-alignment consistently when building cyl and zen WCS

### DIFF
--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -1205,8 +1205,8 @@ def geometry(pos, res=None, shape=None, proj="car", deg=False, pre=(), force=Fal
 		assert(len(ref) == 2)
 	except (TypeError, ValueError):
 		pass
-	if ref is None and not force: ref = "standard"
-	wcs = wcsutils.build(pos, res, shape, rowmajor=True, system=proj, ref=ref, **kwargs)
+	wcs = wcsutils.build(pos, res, shape, rowmajor=True, system=proj,
+                             ref=ref, align=not force, **kwargs)
 	if shape is None:
 		# Infer shape. WCS does not allow us to wrap around the
 		# sky, so shape mustn't be large enough to make that happen.

--- a/tests/test_pixell.py
+++ b/tests/test_pixell.py
@@ -241,14 +241,14 @@ class PixelTests(unittest.TestCase):
 
     def test_plain_wcs(self):
         # Test area and box for a small Cartesian geometry
-        shape,wcs = enmap.geometry(res=np.deg2rad(1./60.),shape=(600,600),pos=(0,0),proj='plain')
+        shape,wcs = enmap.geometry(res=np.deg2rad(1./60.),shape=(600,600),pos=(0,0),force=True,proj='plain')
         box = np.rad2deg(enmap.box(shape,wcs))
         area = np.rad2deg(np.rad2deg(enmap.area(shape,wcs)))
         assert np.all(np.isclose(box,np.array([[-5,-5],[5,5]])))
         assert np.isclose(area,100.)
 
         # and for an artifical Cartesian geometry with area>4pi
-        shape,wcs = enmap.geometry(res=np.deg2rad(10),shape=(100,100),pos=(0,0),proj='plain')
+        shape,wcs = enmap.geometry(res=np.deg2rad(10),shape=(100,100),pos=(0,0),force=True,proj='plain')
         box = np.rad2deg(enmap.box(shape,wcs))
         area = np.rad2deg(np.rad2deg(enmap.area(shape,wcs)))
         assert np.all(np.isclose(box,np.array([[-500,-500],[500,500]])))


### PR DESCRIPTION
Addresses #89 

Support the creation of zenithal WCS with a specified reference point,
but without pixel realignment.  This is achieved by adding argument
"align" to the wcsutils.build function.  The behavior of build and
enmap.geometry are unchanged for cylindrical projections*.  However,
we should consider deprecating build(..., ref='standard') in favor of
build(..., ref=None, align=True).

Footnote: geometry(..., ref='standard', force=True) produces a
different result than previously, even on cylindrical projections.
It's not clear if ref='standard' is valid input, however, and even if
it is, adding force=True to that should probably be invalid.