### PR TITLE
Curved sky helpers

### DIFF
--- a/pixell/curvedsky.py
+++ b/pixell/curvedsky.py
@@ -539,7 +539,7 @@ def almxfl(alm,lfunc,ainfo=None):
 	l = np.arange(ainfo.lmax+1.0)
 	return ainfo.lmul(alm, lfunc(l))
 
-def filter(imap,lmax,lfunc,ainfo=None):
+def filter(imap,lfunc,ainfo=None,lmax=None):
 	"""Filter a map isotropically by a function.
 	Returns alm2map(map2alm(alm * lfunc(ell),lmax))
 
@@ -553,7 +553,7 @@ def filter(imap,lmax,lfunc,ainfo=None):
 	Returns:
 	    omap: (...,Ny,Nx) ndmap stack of filtered enmaps
 	"""
-	return alm2map(almxfl(map2alm(imap,lmax=lmax,spin=0),lfunc,ainfo),enmap.empty(imap.shape,imap.wcs,dtype=imap.dtype),spin=0)
+	return alm2map(almxfl(map2alm(imap,ainfo=ainfo,lmax=lmax,spin=0),lfunc=lfunc,ainfo=ainfo),enmap.empty(imap.shape,imap.wcs,dtype=imap.dtype),spin=0,ainfo=ainfo)
 	
 
 

--- a/pixell/curvedsky.py
+++ b/pixell/curvedsky.py
@@ -539,6 +539,24 @@ def almxfl(alm,lfunc,ainfo=None):
 	l = np.arange(ainfo.lmax+1.0)
 	return ainfo.lmul(alm, lfunc(l))
 
+def filter(imap,lmax,lfunc,ainfo=None):
+	"""Filter a map isotropically by a function.
+	Returns alm2map(map2alm(alm * lfunc(ell),lmax))
+
+	Args:
+	    imap: (...,Ny,Nx) ndmap stack of enmaps.
+	    lmax: integer specifying maximum multipole beyond which the alms are zeroed
+	    lfunc: a function mapping multipole ell to the filtering expression
+	    ainfo: 	If ainfo is provided, it is an alm_info describing the layout 
+	of the input alm. Otherwise it will be inferred from the alm itself.
+
+	Returns:
+	    omap: (...,Ny,Nx) ndmap stack of filtered enmaps
+	"""
+	return alm2map(almxfl(map2alm(imap,lmax=lmax,spin=0),lfunc,ainfo),enmap.empty(imap.shape,imap.wcs,dtype=imap.dtype),spin=0)
+	
+
+
 def alm2cl(alm, alm2=None, ainfo=None):
 	"""Compute the power spectrum for alm, or if alm2 is given, the cross-spectrum
 	between alm and alm2, which must broadcast. 

--- a/pixell/lensing.py
+++ b/pixell/lensing.py
@@ -153,14 +153,10 @@ def lens_map_curved(shape, wcs, phi_alm, cmb_alm, phi_ainfo=None, maplmax=None, 
 		elif c == "a": res.append(grad_map)
 	return tuple(res)
 
-def rand_alm(shape, wcs, ps_lensinput, lmax=None, dtype=np.float64, seed=None, phi_seed=None, verbose=False):
+def rand_alm(ps_lensinput, lmax=None, dtype=np.float64, seed=None, phi_seed=None, verbose=False, ncomp=None):
 	from . import curvedsky, sharp
 	ctype   = np.result_type(dtype,0j)
-	# Restrict to target number of components
-	oshape  = shape[-3:]
-	if len(oshape) == 2: shape = (1,)+tuple(shape)
-	ncomp   = shape[-3]
-	ps_lensinput = ps_lensinput[:1+ncomp,:1+ncomp]
+	if ncomp is not None: ps_lensinput = ps_lensinput[:1+ncomp,:1+ncomp]
 	# First draw a random lensing field, and use it to compute the undeflected positions
 	if verbose: print("Generating alms")
 	if phi_seed is None:
@@ -182,9 +178,14 @@ def rand_alm(shape, wcs, ps_lensinput, lmax=None, dtype=np.float64, seed=None, p
 
 
 def rand_map(shape, wcs, ps_lensinput, lmax=None, maplmax=None, dtype=np.float64, seed=None, phi_seed=None, oversample=2.0, spin=[0,2], output="l", geodesic=True, verbose=False, delta_theta=None):
-	phi_alm, cmb_alm, ainfo = rand_alm(shape=shape, wcs=wcs, ps_lensinput=ps_lensinput, 
-								lmax=lmax, dtype=dtype, seed=seed, 
-								phi_seed=phi_seed, verbose=verbose)
+	# Restrict to target number of components
+	oshape  = shape[-3:]
+	if len(oshape) == 2: shape = (1,)+tuple(shape)
+	ncomp   = shape[-3]
+	phi_alm, cmb_alm, ainfo = rand_alm(ps_lensinput=ps_lensinput, 
+									   lmax=lmax, dtype=dtype, seed=seed, 
+									   phi_seed=phi_seed, verbose=verbose,
+									   ncomp=ncomp)
 
 	# Truncate alm if we want a smoother map. In taylens, it was necessary to truncate
 	# to a lower lmax for the map than for phi, to avoid aliasing. The appropriate lmax

--- a/pixell/lensing.py
+++ b/pixell/lensing.py
@@ -153,8 +153,7 @@ def lens_map_curved(shape, wcs, phi_alm, cmb_alm, phi_ainfo=None, maplmax=None, 
 		elif c == "a": res.append(grad_map)
 	return tuple(res)
 
-
-def rand_map(shape, wcs, ps_lensinput, lmax=None, maplmax=None, dtype=np.float64, seed=None, phi_seed=None, oversample=2.0, spin=[0,2], output="l", geodesic=True, verbose=False, delta_theta=None):
+def rand_alm(shape, wcs, ps_lensinput, lmax=None, dtype=np.float64, seed=None, phi_seed=None, verbose=False):
 	from . import curvedsky, sharp
 	ctype   = np.result_type(dtype,0j)
 	# Restrict to target number of components
@@ -178,8 +177,15 @@ def rand_map(shape, wcs, ps_lensinput, lmax=None, maplmax=None, dtype=np.float64
 		alm[:,:ainfo.lmax].real *= 2**0.5
 		del wps, ps12
 		
-	phi_alm, cmb_alm = alm[0], alm[1:]
-	del alm
+	# Return phi_alm and cmb_alm
+	return alm[0], alm[1:], ainfo
+
+
+def rand_map(shape, wcs, ps_lensinput, lmax=None, maplmax=None, dtype=np.float64, seed=None, phi_seed=None, oversample=2.0, spin=[0,2], output="l", geodesic=True, verbose=False, delta_theta=None):
+	phi_alm, cmb_alm, ainfo = rand_alm(shape=shape, wcs=wcs, ps_lensinput=ps_lensinput, 
+								lmax=lmax, dtype=dtype, seed=seed, 
+								phi_seed=phi_seed, verbose=verbose)
+
 	# Truncate alm if we want a smoother map. In taylens, it was necessary to truncate
 	# to a lower lmax for the map than for phi, to avoid aliasing. The appropriate lmax
 	# for the cmb was the one that fits the resolution. FIXME: Can't slice alm this way.


### PR DESCRIPTION
This PR adds two features:
1. Add a function to `pixell.curvedsky` to filter a map with SHTs
2. Add `lensing.rand_alm` called by `lensing.rand_map` so that the unlensed alms and phi alms can be reproduced