### PR TITLE
Import from development branch: bunch I/O, 1d SHTs, np.interp wrapper, block reduce/expand, crossmatching, grouping

### DIFF
--- a/pixell/bunch.py
+++ b/pixell/bunch.py
@@ -49,3 +49,34 @@ class Bunch:
 		return "Bunch(" + ", ".join([
 			"%s=%s" % (str(key),repr(self._dict[key])) for key in keys
 			])+")"
+
+# Some simple I/O routines. These can't handle everything that could
+# be in a bunch, but they cover all my most common use cases.
+
+def read(fname, fmt="auto"):
+	if fmt == "auto":
+		if fname.endswith(".hdf"): fmt = "hdf"
+		else: raise ValueError("Could not infer format for '%s'" % fname)
+	if fmt == "hdf": return read_hdf(fname)
+	else: raise ValueError("Unrecognized format '%s'" % fmt)
+
+def write(fname, bunch, fmt="auto"):
+	if fmt == "auto":
+		if fname.endswith(".hdf"): fmt = "hdf"
+		else: raise ValueError("Could not infer format for '%s'" % fname)
+	if fmt == "hdf": write_hdf(fname, bunch)
+	else: raise ValueError("Unrecognized format '%s'" % fmt)
+
+def write_hdf(fname, bunch):
+	import h5py
+	with h5py.File(fname, "w") as hfile:
+		for key in bunch:
+			hfile[key] = bunch[key]
+
+def read_hdf(fname):
+	import h5py
+	bunch = Bunch()
+	with h5py.File(fname, "r") as hfile:
+		for key in hfile:
+			bunch[key] = hfile[key][()]
+	return bunch

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -1121,8 +1121,8 @@ def map_mul(mat, vec):
 	"""Elementwise matrix multiplication mat*vec. Result will have
 	the same shape as vec. Multiplication happens along the last non-pixel
 	indices."""
-	# Allow scalar product
-	if mat.ndim == 2 and vec.ndim == 2: return mat*vec
+	# Allow scalar product, broadcasting if necessary
+	if mat.ndim < 3: return mat*vec
 	# Otherwise we do a matrix product along the last axes
 	ovec = samewcs(np.einsum("...abyx,...byx->...ayx", mat, vec), mat, vec)
 	return ovec
@@ -1830,7 +1830,7 @@ def rbin(map, center=[0,0], bsize=None, brel=1.0, return_nhit=False):
 	the pixel size. brel can be used to scale up the bin size. This is
 	mostly useful when using automatic bsize.
 
-	Returns bvals[...,nbin] and r[nbin], where bvals is the mean
+	Returns bvals[...,nbin], r[nbin], where bvals is the mean
 	of the map in each radial bin and r is the mid-point of each bin
 	"""
 	r = map.modrmap(ref=center)

--- a/pixell/enplot.py
+++ b/pixell/enplot.py
@@ -317,7 +317,7 @@ def parse_args(args=sys.argv[1:], noglob=False):
 	if not noglob:
 		ifiles = []
 		for pattern in res.ifiles:
-			matches = glob.glob(pattern)
+			matches = sorted(glob.glob(pattern))
 			if len(matches) > 0:
 				ifiles += matches
 			else:

--- a/pixell/utils.py
+++ b/pixell/utils.py
@@ -215,10 +215,13 @@ def mjd2ctime(mjd):
 	"""Converts from modified julian date to unix time"""
 	return (np.asarray(mjd)-40587.0)*86400
 
-def medmean(x, frac=0.5):
-	x = np.sort(x.reshape(-1))
-	i = int(x.size*frac)//2
-	return np.mean(x[i:-i])
+def medmean(x, axis=None, frac=0.5):
+	x = np.asarray(x)
+	if axis is None: x = x.reshape(-1)
+	else:            x = np.moveaxis(x, axis, -1)
+	x = np.sort(x, -1)
+	i = int(x.shape[-1]*frac)//2
+	return np.mean(x[...,i:-i],-1)
 
 def moveaxis(a, o, n):
 	if o < 0: o = o+a.ndim
@@ -1636,6 +1639,45 @@ def block_mean_filter(a, width):
 		a[:]   = work[...,:a.shape[-1]]
 	return a
 
+def block_reduce(a, bsize, op=np.mean):
+	"""Replace each block of length bsize along the last axis of a
+	with an aggregate value given by the operation op. op must
+	accept op(array, axis), just like np.sum or np.mean. a need not
+	have a whole number of blocks. In that case, the last block will
+	have fewer than bsize samples in it."""
+	if bsize == 1: return a
+	a     = np.asarray(a)
+	nsamp = a.shape[-1]
+	nwhole= nsamp//bsize
+	blocks= a[...,:nwhole*bsize].reshape(a.shape[:-1]+(nwhole,bsize))
+	vals  = op(blocks, -1)
+	if nwhole*bsize != nsamp:
+		vals = np.concatenate([vals, op(a[...,None,nwhole*bsize:],-1)],-1)
+	return vals
+
+def block_expand(a, bsize, osize, op="nearest"):
+	nwhole = osize//bsize
+	nrest  = osize-nwhole*bsize
+	if op == "nearest":
+		bind = np.arange(osize)//bsize
+		return a[...,bind]
+	elif op == "linear":
+		# Index relative to block centers. For bsize samples in a block,
+		# the intervals have size 1/nblock, and the first sample is offset
+		# by half an interval. Hence sample #i is at ((i+1)+0.5)/nblock-0.5
+		find   = (np.arange(nwhole*bsize)+0.5)/bsize - 0.5
+		if nrest != 0:
+			find = np.concatenate([find, nwhole + (np.arange(nrest)+0.5)/nrest-0.5])
+		i1 = np.floor(find).astype(int)
+		i2 = i1+1
+		x2 = find % 1
+		x1 = 1 - x2
+		i1 = np.maximum(i1, 0)
+		i2 = np.minimum(i2, a.shape[-1]-1)
+		return a[...,i1]*x1 + a[...,i2]*x2
+	else:
+		raise ValueError("Unrecognized operation '%s'" % op)
+
 def ctime2date(timestamp, tzone=0, fmt="%Y-%m-%d"):
 	return datetime.datetime.utcfromtimestamp(timestamp+tzone*3600).strftime(fmt)
 
@@ -2244,3 +2286,82 @@ def jname(ra, dec, fmt="J%(ra_H)02d%(ra_M)02d%(ra_S)02d%(dec_d)+02d%(dec_m)02d%(
 		"ra_H" :rah[0]*rah[1], "ra_M" : rah[2], "ra_S" : rah[3],
 		"dec_d":ded[0]*ded[1], "dec_m": ded[2], "dec_s": ded[3],
 		"dec_H":deh[0]*deh[1], "dec_M": deh[2], "dec_S": deh[3]}
+
+def crossmatch(pos1, pos2, rmax, mode="closest", coords="auto"):
+	"""Find close matches between positions given by pos1[:,ndim] and pos2[:,ndim],
+	up to a maximum distance of rmax (in the same units as the positions).
+
+	The argument "coords" controls how the coordinates are interpreted. If it is
+	"cartesian", then they are assumed to be cartesian coordinates. If it is
+	"radec" or "phitheta", then the coordinates are assumed to be angles in radians,
+	which will be transformed to coordinates internally before being used. "radec"
+	is equator-based while "phitheta" is zenith-based. The default, "auto", will assume
+	"radec" if ndim == 2, and "cartesian" otherwise.
+
+	It's possible that multiple objects from the catalogs are within rmax of each
+	other. The "mode" argument controls how this is handled.
+	mode == "all":
+	 Returns a list of pairs of indices into the two lists, one for each pair of
+	 objects that are close enough to each other, regardless of the presence of
+	 any other matches. Any given object can be mentioned multiple times in this
+	 list.
+	mode == "closest":
+	 Like "all", but only the closest time an index appears in a pair is kept, the
+	 others are discarded.
+	mode == "first":
+	 Like "all", but only the first time an index appears in a pair is kept, the
+	 others are discarted. This can be useful if some objects should be given
+	 higher priority than others. For example, one could sort pos1 and pos2 by
+	 brightness and then use mode == "first" to prefer bright objects in the match."""
+	from scipy import spatial
+	
+	pos1 = np.asarray(pos1); n1 = len(pos1)
+	pos2 = np.asarray(pos2); n2 = len(pos2)
+
+	assert pos1.ndim == 2, "crossmatch: pos1 must be [npoint,ndim], but was %s" % str(pos1.shape)
+	assert pos2.ndim == 2, "crossmatch: pos2 must be [npoint,ndim], but was %s" % str(pos2.shape)
+	assert pos1.shape[1] == pos2.shape[1], "crossmatch: pos1's shape %s is incompatible with pos2's shape %s" % (str(pos1.shape), str(pos2.shape))
+
+	# Normalize the coordinates
+	if coords == "auto":
+		coords = "radec" if pos1.shape[1] == 2 else "cartesian"
+	if coords == "radec":
+		trans = lambda pos: ang2rect(pos, zenith=False, axis=1)
+	elif coords == "phitheta":
+		trans = lambda pos: ang2rect(pos, zenith=True,  axis=1)
+	elif coords == "cartesian":
+		trans = lambda pos: pos
+	else:
+		raise ValueError("crossmatch: Unrecognized value for coords: %s" % (str(coords)))
+	pos1 = trans(pos1)
+	pos2 = trans(pos2)
+
+	# Start by generating the full list
+	tree1   = spatial.cKDTree(pos1)
+	tree2   = spatial.cKDTree(pos2)
+	matches = tree1.query_ball_tree(tree2, r=rmax)
+	pairs   = [(i1,i2) for i1, group in enumerate(matches) for i2 in group]
+
+	if mode == "all":
+		return pairs
+	else:
+		if mode == "first":
+			# "first" mode only keeps the first group an object appears in. So the pairs
+			# are already in the right order.
+			pass
+		elif mode == "closest":
+			parr   = np.array(pairs)
+			d2     = np.sum((pos1[parr[:,0]]-pos2[parr[:,1]])**2,1)
+			order  = np.argsort(d2)
+			pairs  = [pairs[i] for i in order]
+		else:
+			raise ValueError("crossmatch: Unrecognized mode: %s" % (str(mode)))
+		# Filter out all but the first mention of each
+		done1 = np.zeros(n1, bool)
+		done2 = np.zeros(n2, bool)
+		opairs= []
+		for i1, i2 in pairs:
+			if done1[i1] or done2[i2]: continue
+			done1[i1] = done2[i2] = True
+			opairs.append((i1,i2))
+		return opairs


### PR DESCRIPTION
This is an import from my development repository. Mostly minor "nice-to-have" utilities. The most notable changes are probably bunch.write/read, which I think are quite handy; curvedsky.profile2harm/harm2profile, which makes it easy to transform e.g. a beam between its harmonic space and real-space representations, and utils.crossmatch, which provides quite fast and general crossmatching functionality.