### PR TITLE
Thumbnails: pixel window deconvolution and unit tests

### DIFF
--- a/pixell/reproject.py
+++ b/pixell/reproject.py
@@ -644,4 +644,5 @@ def thumbnails_ivar(imap, coords, r=5*utils.arcmin, res=None, proj="tan",
 	combined. An example of this is a hitcount map or ivar per pixel. Conversely, if
 	you have an intensive quantity like ivar per arcmin you should set extensive=False."""
 	return thumbnails(imap, coords, r=r, res=res, proj=proj, oshape=oshape, owcs=owcs,
-			order=1, oversample=1, pol=False, extensive=extensive, verbose=verbose,)
+			order=1, oversample=1, pol=False, extensive=extensive, verbose=verbose,
+			pixwin=False)

--- a/pixell/reproject.py
+++ b/pixell/reproject.py
@@ -612,10 +612,7 @@ def thumbnails(imap, coords, r=5*utils.arcmin, res=None, proj="tan", apod=2*util
 		ithumb = imap.extract_pixbox(pixbox)
 		if extensive: ithumb /= ithumb.pixsizemap()
 		ithumb = ithumb.apod(apod_pix, fill="median")
-		if pixwin:
-			wy, wx = enmap.calc_window(ithumb.shape[-2:])
-			ptransfer = wy[:,None]**(-1) * wx[None,:]**(-1)
-			ithumb = enmap.ifft(ptransfer*enmap.fft(ithumb)).real
+		if pixwin: ithumb = enmap.apply_window(ithumb, -1)
 		if filter is not None: ithumb = filter(ithumb)
 		if verbose:
 			print("%4d/%d %6.2f %6.2f %8.2f %dx%d" % (si+1, nsrc, coords[si,0]/utils.degree, coords[si,1]/utils.degree, np.max(ithumb), ithumb.shape[-2], ithumb.shape[-1]))

--- a/pixell/tests/test_pixell.py
+++ b/pixell/tests/test_pixell.py
@@ -579,7 +579,7 @@ class PixelTests(unittest.TestCase):
         np.testing.assert_array_almost_equal(omap, omap_exp)
 
     def test_thumbnails(self):
-        print("Testing thumbnails (slow)...")
+        print("Testing thumbnails...")
 
         # Make a geometry far away from the equator
         dec_min = 70 * u.degree

--- a/pixell/tests/test_pixell.py
+++ b/pixell/tests/test_pixell.py
@@ -603,22 +603,21 @@ class PixelTests(unittest.TestCase):
         ps = np.vstack((yy,xx))
         decs,ras = enmap.pix2sky(shape,wcs,ps)
         
-        # Simulate these sources with unit flux and 2.5 arcmin FWHM
+        # Simulate these sources with unit peak value and 2.5 arcmin FWHM
         N = ps.shape[1]
         srcs = np.zeros((N,3))
         srcs[:,0] = decs
         srcs[:,1] = ras
         srcs[:,2] = ras*0 + 1
-        fwhm = 2.5 * u.arcmin
-        sigma = fwhm/2./np.sqrt(2.*np.log(2.))
+        sigma = 2.5 * u.fwhm * u.arcmin
         omap = pointsrcs.sim_srcs(shape,wcs,srcs,beam=sigma)
 
         # Reproject thumbnails centered on the sources
         # with gnomonic/tangent projection
         proj = "tan"
         r = 10*u.arcmin
-        ret = reproject.thumbnails(omap, srcs[:,:2], r=r, res=res, proj=proj, apod=2*u.arcmin,
-                order=3, oversample=2,pixwin=False)
+        ret = reproject.thumbnails(omap, srcs[:,:2], r=r, res=res, proj=proj, 
+            apod=2*u.arcmin, order=3, oversample=2,pixwin=False)
 
         # Create a reference source at the equator to compare this against
         ishape,iwcs = enmap.geometry(shape=ret.shape,res=res,pos=(0,0),proj=proj)


### PR DESCRIPTION
I'll do spaces -> tabs throughout reproject.py in a separate PR or commit.