### PR TITLE
Fix issues with builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           python -m pip install -U pip
           python -m easy_install -U setuptools
           python -m pip install pytest-cov numpy
-          python -m pip install cibuildwheel==1.8.0
+          python -m pip install cibuildwheel
 
       - name: Test and build wheels
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest]
+        os: [ubuntu-20.04, macos-10.15]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements =  ['numpy>=1.16',
+requirements =  ['numpy>=1.20',
                  'astropy>=2.0',
                  'setuptools>=39',
                  'h5py>=2.7<=2.10',


### PR DESCRIPTION
Merging soon. This should fix the numpy binary incompatibility issue facing recent release versions. (Main change is requiring numpy > v1.20.0)