### PR TITLE
Update copyright in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
 
 BSD License
 
-Copyright (c) 2021, Members of the Simons Observatory Collaboration
+Copyright (c) 2018-2021, Members of the Simons Observatory Collaboration
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
 
 BSD License
 
-Copyright (c) 2018, Simons Observatory Collaboration Analysis Library Task Force
+Copyright (c) 2021, Members of the Simons Observatory Collaboration
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
The previous copyright reference to "Analysis Library Task Force" was vague. This updates the copyright to belong to Members of the Simons Observatory Collaboration.