### PR TITLE
Allow later versions of h5py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with open('HISTORY.rst') as history_file:
 requirements =  ['numpy>=1.20',
                  'astropy>=2.0',
                  'setuptools>=39',
-                 'h5py>=2.7,<=2.10',
+                 'h5py>=2.7',
                  'scipy>=1.0',
                  'python_dateutil>=2.7',
                  'cython>=0.28',


### PR DESCRIPTION
Unclear why this was limited to <2.10 earlier.. let's see how the builds go.