### PR TITLE
Potentially breaking change: map2alm now no longer silently approxima…

### DIFF
--- a/pixell/curvedsky.py
+++ b/pixell/curvedsky.py
@@ -621,7 +621,7 @@ def match_predefined_minfo(shape, wcs, rtol=None, atol=None):
 	aoff /= pixheight
 	roff /= pixheight
 	if not roff < rtol: raise ShapeError("Could not find a map_info with predefined quadrature weights matching input map (rel offset %e >= %e). Pass tweak=True to map2alm to allow it to use slightly shifted pixel positions to match a geometry for which a predefined quadrature exists. This matches the old default. The resulted slightly shifted alms can be projected back onto the original pixels by passing tweak=True to alm2map." % (aoff, atol))
-	if not aoff < atol: raise ShapeError("Could not find a map_info with predefined weights matching input map (abs offset %e >= %e). Pass tweak=True to map2alm to allow it to use slightly shifted pixel positions to match a geometry for which a predefined quadrature exists. This matches the old default. The resulted slightly shifted alms can be projected back onto the original pixels by passing tweak=True to alm2map." % (aoff, atol))
+	if not aoff < atol: raise ShapeError("Could not find a map_info with predefined quadrature weights matching input map (abs offset %e >= %e). Pass tweak=True to map2alm to allow it to use slightly shifted pixel positions to match a geometry for which a predefined quadrature exists. This matches the old default. The resulted slightly shifted alms can be projected back onto the original pixels by passing tweak=True to alm2map." % (aoff, atol))
 	minfo = minfos2[best]
 	# Modify the minfo to restrict it to only the rows contained in the geometry
 	minfo_cut = sharp.map_info(

--- a/pixell/curvedsky.py
+++ b/pixell/curvedsky.py
@@ -620,8 +620,8 @@ def match_predefined_minfo(shape, wcs, rtol=None, atol=None):
 	pixheight = np.abs(wcs.wcs.cdelt[1]*utils.degree)
 	aoff /= pixheight
 	roff /= pixheight
-	if not roff < rtol: raise ShapeError("Could not find a map_info with predefined weights matching input map (rel offset %e >= %e)" % (aoff, atol))
-	if not aoff < atol: raise ShapeError("Could not find a map_info with predefined weights matching input map (abs offset %e >= %e)" % (aoff, atol))
+	if not roff < rtol: raise ShapeError("Could not find a map_info with predefined quadrature weights matching input map (rel offset %e >= %e). Pass tweak=True to map2alm to allow it to use slightly shifted pixel positions to match a geometry for which a predefined quadrature exists. This matches the old default. The resulted slightly shifted alms can be projected back onto the original pixels by passing tweak=True to alm2map." % (aoff, atol))
+	if not aoff < atol: raise ShapeError("Could not find a map_info with predefined weights matching input map (abs offset %e >= %e). Pass tweak=True to map2alm to allow it to use slightly shifted pixel positions to match a geometry for which a predefined quadrature exists. This matches the old default. The resulted slightly shifted alms can be projected back onto the original pixels by passing tweak=True to alm2map." % (aoff, atol))
 	minfo = minfos2[best]
 	# Modify the minfo to restrict it to only the rows contained in the geometry
 	minfo_cut = sharp.map_info(

--- a/pixell/curvedsky.py
+++ b/pixell/curvedsky.py
@@ -73,7 +73,7 @@ def rand_alm(ps, ainfo=None, lmax=None, seed=None, dtype=np.complex128, m_major=
 ### Top-level wrappers ###
 ##########################
 
-def alm2map(alm, map, ainfo=None, spin=[0,2], deriv=False, direct=False, copy=False, oversample=2.0, method="auto", verbose=False, map2alm_adjoint=False, rtol=None, atol=None):
+def alm2map(alm, map, ainfo=None, spin=[0,2], deriv=False, direct=False, copy=False, oversample=2.0, method="auto", verbose=False, map2alm_adjoint=False, tweak=False, rtol=None, atol=None):
 	"""Project the spherical harmonics coefficients alm[...,nalm] onto the
 	enmap map[...,ny,nx].
 
@@ -100,7 +100,7 @@ def alm2map(alm, map, ainfo=None, spin=[0,2], deriv=False, direct=False, copy=Fa
 	internally to implement map2alm_adjoint.
 	"""
 	if method == "cyl":
-		alm2map_cyl(alm, map, ainfo=ainfo, spin=spin, deriv=deriv, direct=direct, copy=copy, verbose=verbose, map2alm_adjoint=map2alm_adjoint, rtol=rtol, atol=atol)
+		alm2map_cyl(alm, map, ainfo=ainfo, spin=spin, deriv=deriv, direct=direct, copy=copy, verbose=verbose, tweak=tweak, map2alm_adjoint=map2alm_adjoint, rtol=rtol, atol=atol)
 	elif method == "pos":
 		if verbose: print("Computing pixel positions %s dtype d" % str((2,)+map.shape[-2:]))
 		pos = map.posmap()
@@ -109,7 +109,7 @@ def alm2map(alm, map, ainfo=None, spin=[0,2], deriv=False, direct=False, copy=Fa
 	elif method == "auto":
 		# Cylindrical method if possible, else slow pos-based method
 		try:
-			alm2map_cyl(alm, map, ainfo=ainfo, spin=spin, deriv=deriv, direct=direct, copy=copy, verbose=verbose, map2alm_adjoint=map2alm_adjoint, rtol=rtol, atol=atol)
+			alm2map_cyl(alm, map, ainfo=ainfo, spin=spin, deriv=deriv, direct=direct, copy=copy, verbose=verbose, tweak=tweak, map2alm_adjoint=map2alm_adjoint, rtol=rtol, atol=atol)
 		except ShapeError as e:
 			# Wrong pixelization. Fall back on slow, general method
 			if verbose: print("Computing pixel positions %s dtype d" % str((2,)+map.shape[-2:]))
@@ -121,7 +121,7 @@ def alm2map(alm, map, ainfo=None, spin=[0,2], deriv=False, direct=False, copy=Fa
 	return map
 
 def map2alm(map, alm=None, ainfo=None, lmax=None, spin=[0,2], direct=False, copy=False,
-		oversample=2.0, method="auto", rtol=None, atol=None, alm2map_adjoint=False):
+		oversample=2.0, method="auto", tweak=False, rtol=None, atol=None, alm2map_adjoint=False):
 	"""Spherical harmonics analysis of the enmap map[...,ny,nx] into the spherical harmonics
 	coefficients alm[...,nalm]. The (approximate) inverse of alm2map. To support partial
 	sky coverage and arbitrary projections, an intermediate map will be constructed
@@ -142,32 +142,26 @@ def map2alm(map, alm=None, ainfo=None, lmax=None, spin=[0,2], direct=False, copy
 	map can be skipped by passing the direct=True argument.
 
 	The alm2map_adjoint argument is used internally to implement the alm2map_adjoint function."""
-	if method == "cyl":
+	if method == "cyl" or method == "auto":
 		alm = map2alm_cyl(map, alm, ainfo=ainfo, lmax=lmax, spin=spin, direct=direct,
-				copy=copy, rtol=rtol, atol=atol, alm2map_adjoint=alm2map_adjoint)
+				copy=copy, tweak=tweak, rtol=rtol, atol=atol, alm2map_adjoint=alm2map_adjoint)
 	elif method == "pos":
 		raise NotImplementedError("map2alm for noncylindrical layouts not implemented")
-	elif method == "auto":
-		try:
-			alm = map2alm_cyl(map, alm, ainfo=ainfo, lmax=lmax, spin=spin, direct=direct,
-					copy=copy, rtol=rtol, atol=atol, alm2map_adjoint=alm2map_adjoint)
-		except ShapeError as e:
-			raise NotImplementedError("map2alm for noncylindrical layouts not implemented")
 	else:
 		raise ValueError("Unknown alm2map method %s" % method)
 	return alm
 
 # Adjoints
 
-def map2alm_adjoint(alm, map, ainfo=None, spin=[0,2], direct=False, copy=False, oversample=2.0, method="auto", verbose=False, rtol=None, atol=None):
+def map2alm_adjoint(alm, map, ainfo=None, spin=[0,2], direct=False, copy=False, oversample=2.0, method="auto", verbose=False, tweak=False, rtol=None, atol=None):
 	"""Adjoint of map2alm"""
-	return alm2map(alm, map, ainfo=ainfo, spin=spin, direct=direct, copy=copy, oversample=oversample, method=method, verbose=verbose, map2alm_adjoint=True, rtol=rtol, atol=atol)
+	return alm2map(alm, map, ainfo=ainfo, spin=spin, direct=direct, copy=copy, oversample=oversample, method=method, verbose=verbose, tweak=tweak, map2alm_adjoint=True, rtol=rtol, atol=atol)
 
 def alm2map_adjoint(map, alm=None, ainfo=None, lmax=None, spin=[0,2], direct=False, copy=False,
-		oversample=2.0, method="auto", rtol=None, atol=None):
+		oversample=2.0, method="auto", tweak=False, rtol=None, atol=None):
 	"""Adjoint of alm2map"""
 	return map2alm(map, alm=alm, ainfo=ainfo, lmax=lmax, spin=spin, direct=direct, copy=copy,
-		oversample=oversample, method=method, rtol=rtol, atol=atol, alm2map_adjoint=True)
+		oversample=oversample, method=method, tweak=tweak, rtol=rtol, atol=atol, alm2map_adjoint=True)
 
 # Quadrature weights
 
@@ -220,7 +214,7 @@ def map2alm_adjoint_pos(alm, pos, ainfo=None, oversample=2.0, spin=[0,2], deriv=
 # system is extended internally if necessary. minfo is built
 # internally automatically.
 
-def alm2map_cyl(alm, map, ainfo=None, spin=[0,2], deriv=False, direct=False, copy=False, verbose=False, map2alm_adjoint=False, rtol=None, atol=None):
+def alm2map_cyl(alm, map, ainfo=None, spin=[0,2], deriv=False, direct=False, copy=False, verbose=False, map2alm_adjoint=False, rtol=None, atol=None, tweak=False):
 	"""When called as alm2map(alm, map) projects those alms onto that map.
 	alms are interpreted according to ainfo if specified.
 
@@ -246,8 +240,7 @@ def alm2map_cyl(alm, map, ainfo=None, spin=[0,2], deriv=False, direct=False, cop
 	if direct: tmap, mslices, tslices = map, [(Ellipsis,)], [(Ellipsis,)]
 	else:      tmap, mslices, tslices = make_projectable_map_cyl(map, verbose=verbose)
 	if verbose: print("Performing alm2map")
-	if map2alm_adjoint: minfo = match_predefined_minfo(tmap.shape, tmap.wcs, rtol=rtol, atol=atol)
-	else:               minfo = map2minfo(tmap)
+	minfo = get_minfo(tmap.shape, tmap.wcs, quad=map2alm_adjoint, tweak=tweak, rtol=rtol, atol=atol)
 	alm2map_raw(alm, tmap, ainfo, minfo, spin=spin, deriv=deriv, map2alm_adjoint=map2alm_adjoint)
 	for mslice, tslice in zip(mslices, tslices):
 		map[mslice] = tmap[tslice]
@@ -266,7 +259,7 @@ def alm2map_healpix(alm, healmap=None, ainfo=None, nside=None, spin=[0,2], deriv
 			spin=spin, deriv=deriv, copy=copy, map2alm_adjoint=map2alm_adjoint)[...,0]
 
 def map2alm_cyl(map, alm=None, ainfo=None, lmax=None, spin=[0,2], direct=False,
-		copy=False, rtol=None, atol=None, alm2map_adjoint=False):
+		copy=False, tweak=False, rtol=None, atol=None, alm2map_adjoint=False):
 	"""When called as map2alm_cyl(map, alm) computes the alms corresponding
 	to the given map. alms will be ordered according to ainfo if specified.
 	The map must be in a cylindrical projection. If no ring weights
@@ -296,7 +289,7 @@ def map2alm_cyl(map, alm=None, ainfo=None, lmax=None, spin=[0,2], direct=False,
 		tmap[tslice] = map[mslice]
 	# We don't have ring weights for general cylindrical projections.
 	# See if our pixelization matches one with known weights.
-	minfo = match_predefined_minfo(tmap.shape, tmap.wcs, rtol=rtol, atol=atol)
+	minfo = get_minfo(tmap.shape, tmap.wcs, quad=True, tweak=tweak, rtol=rtol, atol=atol)
 	return map2alm_raw(tmap, alm, minfo, ainfo, spin=spin, copy=copy, alm2map_adjoint=alm2map_adjoint)
 
 def map2alm_healpix(healmap, alm=None, ainfo=None, lmax=None, spin=[0,2], copy=False,
@@ -312,9 +305,9 @@ def map2alm_healpix(healmap, alm=None, ainfo=None, lmax=None, spin=[0,2], copy=F
 
 # Adjoints
 
-def map2alm_adjoint_cyl(alm, map, ainfo=None, spin=[0,2], deriv=False, direct=False, copy=False, verbose=False):
+def map2alm_adjoint_cyl(alm, map, ainfo=None, spin=[0,2], deriv=False, direct=False, copy=False, tweak=False, verbose=False):
 	"""Adjoint of map2alm_cyl"""
-	return alm2map_cyl(alm, map, ainfo=ainfo, spin=spin, deriv=deriv, direct=direct, copy=copy, verbose=verbose, map2alm_adjoint=True)
+	return alm2map_cyl(alm, map, ainfo=ainfo, spin=spin, deriv=deriv, direct=direct, copy=copy, tweak=tweak, verbose=verbose, map2alm_adjoint=True)
 
 def map2alm_adjoint_healpix(alm, healmap=None, ainfo=None, nside=None, spin=[0,2], deriv=False, copy=False,
 		theta_min=None, theta_max=None):
@@ -323,10 +316,10 @@ def map2alm_adjoint_healpix(alm, healmap=None, ainfo=None, nside=None, spin=[0,2
 		theta_min=theta_min, theta_max=theta_max, map2alm_adjoint=True)
 
 def alm2map_adjoint_cyl(map, alm=None, ainfo=None, lmax=None, spin=[0,2], direct=False,
-		copy=False, rtol=None, atol=None):
+		copy=False, tweak=False, rtol=None, atol=None):
 	"""Adjoint of alm2map_cyl"""
 	return map2alm_cyl(map, alm=alm, ainfo=ainfo, lmax=lmax, spin=spin, direct=direct,
-		copy=copy, rtol=rtol, atol=atol, alm2map_adjoint=True)
+		copy=copy, tweak=tweak, rtol=rtol, atol=atol, alm2map_adjoint=True)
 
 def alm2map_adjoint_healpix(healmap, alm=None, ainfo=None, lmax=None, spin=[0,2], copy=False,
 		theta_min=None, theta_max=None):
@@ -336,8 +329,8 @@ def alm2map_adjoint_healpix(healmap, alm=None, ainfo=None, lmax=None, spin=[0,2]
 
 # Quadrature weights
 
-def quad_weights_cyl(shape, wcs):
-	return match_predefined_minfo(shape, wcs).weight
+def quad_weights_cyl(shape, wcs, tweak=False):
+	return get_minfo(shape, wcs, quad=True, tweak=tweak).weight
 
 ######################
 ### Raw transforms ###
@@ -542,6 +535,24 @@ def make_projectable_map_by_pos(pos, lmax, dims=(), oversample=2.0, dtype=float,
 	tmap = enmap.zeros(dims+(ny+1,nx),wcs,dtype=dtype)
 	return tmap
 
+def get_minfo(shape, wcs, quad=False, tweak=False, rtol=None, atol=None):
+	"""Get a map info to be used in a spherical harmonics transform for the
+	given geometry (shape, wcs).
+	quad: Specifies whether we need quadrature weights or not. These are only
+	 available for some pixelizations.
+	tweak: Specifies whether we want to tweak how we interpet the wcs object
+	 so that we can match the closest available quadrature, even if it results
+	 in slightly wrong alms. The typical effect of this is that the alms
+	 correspond to the same map, but shifted up or down by a fraction of a pixel.
+	 This option takes effect in the same way whether quad is True or False.
+	 This allows us to perform consistent alm2map and map2alm operations
+	 even when making this approximation, as long as tweak=True is passed to both.
+	rtol and atol: Controls the maximum relative and absolute tolerance allowed
+	 for tweaking, in units of pixels. Defaults to None which implies 1 pixel."""
+	if tweak: return match_predefined_minfo(shape, wcs, rtol=rtol, atol=atol)
+	if quad:  return match_predefined_minfo(shape, wcs, rtol=1e-6, atol=1e-6)
+	else:     return geo2minfo(shape, wcs)
+
 def geo2minfo(shape, wcs):
 	"""Given an enmap geometry with constant-latitude rows and constant longitude
 	intervals, return a corresponding sharp map_info."""
@@ -562,8 +573,8 @@ def match_predefined_minfo(shape, wcs, rtol=None, atol=None):
 	intervals, return the libsharp predefined minfo with ringweights that's
 	the closest match to our pixelization. This function is actually
 	a bit slow, taking about 250 ms. Still subdominant to an SHT, though."""
-	if rtol is None: rtol = 1e-3*utils.arcmin
-	if atol is None: atol = 1.0*utils.arcmin
+	if rtol is None: rtol = 1.0 # 1 pixel local error
+	if atol is None: atol = 1.0 # 1 pixel overall shift
 	# Make sure the colatitude ascends
 	flipy  = wcs.wcs.cdelt[1] > 0
 	if flipy: shape, wcs = enmap.slice_geometry(shape, wcs, [slice(None,None,-1)])
@@ -605,8 +616,12 @@ def match_predefined_minfo(shape, wcs, rtol=None, atol=None):
 	best  = np.argmin(scores)
 	aoff, roff, i1 = aroffs[best]
 	i2 = i1+ntheta
+	# Convert from coordinate errors to pixel errors using the typical pixel height
+	pixheight = np.abs(wcs.wcs.cdelt[1]*utils.degree)
+	aoff /= pixheight
+	roff /= pixheight
+	if not roff < rtol: raise ShapeError("Could not find a map_info with predefined weights matching input map (rel offset %e >= %e)" % (aoff, atol))
 	if not aoff < atol: raise ShapeError("Could not find a map_info with predefined weights matching input map (abs offset %e >= %e)" % (aoff, atol))
-	if not roff < rtol: raise ShapeError("Could not find a map_info with predefined weights matching input map (%rel offset e >= %e)" % (aoff, atol))
 	minfo = minfos2[best]
 	# Modify the minfo to restrict it to only the rows contained in the geometry
 	minfo_cut = sharp.map_info(

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -66,7 +66,7 @@ class ndmap(np.ndarray):
 	def laxes(self, oversample=1, method="auto"): return laxes(self.shape, self.wcs, oversample=oversample, method=method)
 	def lmap(self, oversample=1): return lmap(self.shape, self.wcs, oversample=oversample)
 	def lform(self, shift=True): return lform(self, shift=shift)
-	def modlmap(self, oversample=1): return modlmap(self.shape, self.wcs, oversample=oversample)
+	def modlmap(self, oversample=1, min=0): return modlmap(self.shape, self.wcs, oversample=oversample, min=min)
 	def modrmap(self, ref="center", safe=True, corner=False): return modrmap(self.shape, self.wcs, ref=ref, safe=safe, corner=corner)
 	def lbin(self, bsize=None, brel=1.0, return_nhit=False): return lbin(self, bsize=bsize, brel=brel, return_nhit=return_nhit)
 	def rbin(self, center=[0,0], bsize=None, brel=1.0, return_nhit=False): return rbin(self, center=center, bsize=bsize, brel=brel, return_nhit=return_nhit)
@@ -75,6 +75,8 @@ class ndmap(np.ndarray):
 	def pixshape(self, signed=False): return pixshape(self.shape, self.wcs, signed=signed)
 	def pixsizemap(self, separable="auto", broadcastable=False): return pixsizemap(self.shape, self.wcs, separable=separable, broadcastable=broadcastable)
 	def pixshapemap(self, separable="auto", signed=False): return pixshapemap(self.shape, self.wcs, separable=separable, signed=signed)
+	def lpixsize(self, signed=False, method="auto"): return lpixsize(self.shape, self.wcs, signed=signed, method=method)
+	def lpixshape(self, signed=False, method="auto"): return lpixshape(self.shape, self.wcs, signed=signed, method=method)
 	def extent(self, method="auto", signed=False): return extent(self.shape, self.wcs, method=method, signed=signed)
 	@property
 	def preflat(self):
@@ -1047,11 +1049,13 @@ def lmap(shape, wcs, oversample=1, method="auto"):
 	data[1] = lx[None,:]
 	return ndmap(data, wcs)
 
-def modlmap(shape, wcs, oversample=1, method="auto"):
+def modlmap(shape, wcs, oversample=1, method="auto", min=0):
 	"""Return a map of all the abs wavenumbers in the fourier transform
 	of a map with the given shape and wcs."""
 	slmap = lmap(shape,wcs,oversample=oversample, method=method)
-	return np.sum(slmap**2,0)**0.5
+	l = np.sum(slmap**2,0)**0.5
+	if min > 0: l = np.maximum(l, min)
+	return l
 
 def center(shape,wcs):
 	cpix = (np.array(shape[-2:])-1)/2.
@@ -1092,6 +1096,12 @@ def lrmap(shape, wcs, oversample=1):
 	"""Return a map of all the wavenumbers in the fourier transform
 	of a map with the given shape and wcs."""
 	return lmap(shape, wcs, oversample=oversample)[...,:shape[-1]//2+1]
+
+def lpixsize(shape, wcs, signed=False, method="auto"):
+	return np.product(lpixshape(shape, wcs, signed=signed, method=method))
+
+def lpixshape(shape, wcs, signed=False, method="auto"):
+	return 2*np.pi/extent(shape,wcs, signed=signed, method=method)
 
 def fft(emap, omap=None, nthread=0, normalize=True, adjoint_ifft=False, dct=False):
 	"""Performs the 2d FFT of the enmap pixels, returning a complex enmap.
@@ -2574,7 +2584,7 @@ def resample_fft(fimap, oshape, fomap=None, off=(0,0), corner=False, norm="pix",
 	# different-size fourier spaces can have different units. First handle explicit normalization,
 	# where the factor to multiply is given directly.
 	try: norm = float(norm)
-	except TypeError:
+	except (TypeError, ValueError):
 		# Then handle various normalization conventions.
 		if   norm is None:     norm = 1 # Don't do anything if None is passed. Cost free
 		elif norm == "plain":  norm = fomap.npix/fimap.npix # Corresponds to normalize=False in enmap.ifft

--- a/pixell/uharm.py
+++ b/pixell/uharm.py
@@ -87,6 +87,8 @@ class UHT:
 			self.ntot = np.sum(self.nper)
 		else:
 			raise ValueError("Unrecognized mode in UHT: '%s'" % (str(mode)))
+	@property
+	def npix(self): return self.shape[-2]*self.shape[-1]
 	def map2harm(self, map, spin=0):
 		if self.mode == "flat":
 			return enmap.map2harm(map, spin=spin, normalize="phys")


### PR DESCRIPTION
…tes the wcs when no ring weights are available. It instead raises an exception. To allow the approximation, pass tweak=True. This argument can also be passed to alm2map to make it do exactly the same shift, making these to operations fully compatible with each other even when approximations are needed.