### PR TITLE
Fix ubuntu build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           CIBW_BEFORE_BUILD: "python -m pip install numpy scipy cython"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BUILD: "cp3?-*x86_64"
-          CIBW_SKIP: "cp33-* cp34-* cp35-*"
+          CIBW_SKIP: "cp33-* cp34-* cp35-* *-musllinux_*"
           CIBW_ARCHS_MACOS: "x86_64 arm64 universal2"
           PYTHON: "python"
           PIP: "pip"


### PR DESCRIPTION
Ubuntu builds were failing because cibuildwheel >=2.2 now automatically tries to build for musl as well. Scipy didnt have precompiled wheels for musllinux, so it would try to build scipy, which requires lapack/blas, which ubuntu doesnt come with by default. To get around this, we skip musllinux builds, which we dont plan to support now.