### PR TITLE
Set wcs str to use 0.01 pixel accuracy for crpix instead of variable accuracy

### DIFF
--- a/pixell/wcsutils.py
+++ b/pixell/wcsutils.py
@@ -61,7 +61,7 @@ def describe(wcs):
 	str implementation, this function provides a relpacement."""
 	sys  = wcs.wcs.ctype[0][-3:].lower()
 	n    = wcs.naxis
-	fields = ("cdelt:["+",".join(["%.4g"]*n)+"],crval:["+",".join(["%.4g"]*n)+"],crpix:["+",".join(["%.4g"]*n)+"]") % (tuple(wcs.wcs.cdelt) + tuple(wcs.wcs.crval) + tuple(wcs.wcs.crpix))
+	fields = ("cdelt:["+",".join(["%.4g"]*n)+"],crval:["+",".join(["%.4g"]*n)+"],crpix:["+",".join(["%.1f"]*n)+"]") % (tuple(wcs.wcs.cdelt) + tuple(wcs.wcs.crval) + tuple(wcs.wcs.crpix))
 	pv = wcs.wcs.get_pv()
 	for p in pv:
 		fields += ",pv[%d,%d]=%.3g" % p

--- a/pixell/wcsutils.py
+++ b/pixell/wcsutils.py
@@ -61,7 +61,7 @@ def describe(wcs):
 	str implementation, this function provides a relpacement."""
 	sys  = wcs.wcs.ctype[0][-3:].lower()
 	n    = wcs.naxis
-	fields = ("cdelt:["+",".join(["%.4g"]*n)+"],crval:["+",".join(["%.4g"]*n)+"],crpix:["+",".join(["%.1f"]*n)+"]") % (tuple(wcs.wcs.cdelt) + tuple(wcs.wcs.crval) + tuple(wcs.wcs.crpix))
+	fields = ("cdelt:["+",".join(["%.4g"]*n)+"],crval:["+",".join(["%.4g"]*n)+"],crpix:["+",".join(["%.2f"]*n)+"]") % (tuple(wcs.wcs.cdelt) + tuple(wcs.wcs.crval) + tuple(wcs.wcs.crpix))
 	pv = wcs.wcs.get_pv()
 	for p in pv:
 		fields += ",pv[%d,%d]=%.3g" % p


### PR DESCRIPTION
The wcs pretty-print used to use %.4g format for crpix, but since crpix can often have 5 digits with our maps, that left off important information like the sub-pixel alignment. Changed it to have a fixed 0.01 pixel accuracy instead. This shouldn't make things too verbose.