### PR TITLE
remove redundant line in curvedsky

### DIFF
--- a/pixell/curvedsky.py
+++ b/pixell/curvedsky.py
@@ -580,7 +580,6 @@ def match_predefined_minfo(shape, wcs, rtol=None, atol=None):
 	if flipy: shape, wcs = enmap.slice_geometry(shape, wcs, [slice(None,None,-1)])
 	ntheta, nphi = shape[-2:]
 	theta  = np.pi/2 - enmap.pix2sky(shape, wcs, [np.arange(ntheta),np.zeros(ntheta)])[0]
-	phi0   = enmap.pix2sky(shape, wcs, [1,0])[1]
 	# First find out how many lat rings there are in the whole sky.
 	# Find the first and last pixel center inside bounds
 	y1   = int(np.round(enmap.sky2pix(shape, wcs, [np.pi/2,0])[0]))


### PR DESCRIPTION
Here's the surroundings previously

```python
def match_predefined_minfo(shape, wcs, rtol=None, atol=None):
	"""Given an enmap with constant-latitude rows and constant longitude
	intervals, return the libsharp predefined minfo with ringweights that's
	the closest match to our pixelization. This function is actually
	a bit slow, taking about 250 ms. Still subdominant to an SHT, though."""
	if rtol is None: rtol = 1.0 # 1 pixel local error
	if atol is None: atol = 1.0 # 1 pixel overall shift
	# Make sure the colatitude ascends
	flipy  = wcs.wcs.cdelt[1] > 0
	if flipy: shape, wcs = enmap.slice_geometry(shape, wcs, [slice(None,None,-1)])
	ntheta, nphi = shape[-2:]
	theta  = np.pi/2 - enmap.pix2sky(shape, wcs, [np.arange(ntheta),np.zeros(ntheta)])[0]
	phi0   = enmap.pix2sky(shape, wcs, [1,0])[1]
	# First find out how many lat rings there are in the whole sky.
	# Find the first and last pixel center inside bounds
	y1   = int(np.round(enmap.sky2pix(shape, wcs, [np.pi/2,0])[0]))
	y2   = int(np.round(enmap.sky2pix(shape, wcs, [-np.pi/2,0])[0]))
	phi0 = enmap.pix2sky(shape, wcs, [0,0])[1]
	ny   = utils.nint(y2-y1+1)
	nx   = utils.nint(np.abs(360./wcs.wcs.cdelt[0]))
	# Define our candidate pixelizations
	minfos = []
```
The `phi0` computed the first time does nothing.