### PR TITLE
Change clobber argument to overwrite

### DIFF
--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -318,8 +318,8 @@ def corners(shape, wcs, npoint=10, corner=True):
 	and undoing any sudden jumps in coordinates it finds. This is controlled by
 	the npoint option. The default of 10 should be more than enough.
 
-	Returns [{bottom left,top right},{dec,ra}] in radians 
-	(or equivalent for other coordinate systems). 
+	Returns [{bottom left,top right},{dec,ra}] in radians
+	(or equivalent for other coordinate systems).
 	e.g. an array of the form [[dec_min, ra_min ], [dec_max, ra_max]]."""
 	# Because of wcs's wrapping, we need to evaluate several
 	# extra pixels to make our unwinding unambiguous
@@ -2301,7 +2301,10 @@ def write_fits(fname, emap, extra={}, allow_modify=False):
 		utils.mkdir(os.path.dirname(fname))
 	with warnings.catch_warnings():
 		warnings.filterwarnings('ignore')
-		hdus.writeto(fname, clobber=True)
+		if astropy.__version__ < '5.1':
+			hdus.writeto(fname, clobber=True)
+		else:
+			hdus.writeto(fname, overwrite=True)
 
 def write_fits_geometry(fname, shape, wcs):
 	"""Write just the geometry to a fits file that will only contain the header"""
@@ -2656,4 +2659,3 @@ def spin_helper(spin, n):
 		if i2 == n: break
 		i1 = i2
 		ci = (ci+1)%len(spin)
-

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -2301,10 +2301,7 @@ def write_fits(fname, emap, extra={}, allow_modify=False):
 		utils.mkdir(os.path.dirname(fname))
 	with warnings.catch_warnings():
 		warnings.filterwarnings('ignore')
-		if astropy.__version__ < '5.1':
-			hdus.writeto(fname, clobber=True)
-		else:
-			hdus.writeto(fname, overwrite=True)
+		hdus.writeto(fname, overwrite=True)
 
 def write_fits_geometry(fname, shape, wcs):
 	"""Write just the geometry to a fits file that will only contain the header"""

--- a/pixell/multimap.py
+++ b/pixell/multimap.py
@@ -226,7 +226,7 @@ def write_map(fname, mmap, extra={}):
 	utils.mkdir(os.path.dirname(fname))
 	with warnings.catch_warnings():
 		warnings.filterwarnings('ignore')
-		hdus.writeto(fname, clobber=True)
+		hdus.writeto(fname, overwrite=True)
 
 def read_map(fname, sel=None, box=None, wrap="auto", mode=None, sel_threshold=10e6, verbose=False):
 	"""Read a multimap from the file fname."""

--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -14,7 +14,7 @@ if [[ "$RUNNER_OS" == "macOS" ]]; then
     # supported macos version is: High Sierra / 10.13. When upgrading this, be
     # sure to update the MACOSX_DEPLOYMENT_TARGET environment variable in
     # wheels.yml accordingly. Note that Darwin_17 == High Sierra / 10.13.
-    FILE=libomp-12.0.1_0+universal.darwin_17.i386-x86_64.tbz2
+    FILE=libomp-14.0.4_0+universal.darwin_17.i386-x86_64.tbz2
     wget https://packages.macports.org/libomp/$FILE
     sudo tar -C / -xvjf $FILE opt
 


### PR DESCRIPTION
`clobber` argument when writing a `fits` file has been deprecated since few months now and has been
officially removed in version 5.1 of `astropy` (see https://github.com/astropy/astropy/blob/main/CHANGES.rst#astropyiofits-1)

This PR proposes to use the correct `overwrite` arguments but still makes the change backward compatible. This should also fix the github actions that are currently failing.