### PR TITLE
Fixes for running on Apple Silicon

### DIFF
--- a/cython/sharp_utils.c
+++ b/cython/sharp_utils.c
@@ -1,5 +1,7 @@
 #include "sharp_utils.h"
+#if 0
 #include <immintrin.h>
+#endif
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,12 @@ elif sys.platform == 'darwin':
         sp.check_call('scripts/osx.sh', shell=True)
     except sp.CalledProcessError:
         raise DistutilsError('Failed to prepare Mac OS X properly. See earlier errors.')
+    # Try to find gcc in /usr/local/bin/ (which is where it's installed by homebrew on
+    # Intel) or, if that fails, /opt/homebrew/bin/ (which is where it's installed by
+    # homebrew on Silicon)
     gccpath = glob.glob('/usr/local/bin/gcc-*')
+    if not gccpath:
+        gccpath = glob.glob('/opt/homebrew/bin/gcc-*')
     if gccpath:
         # Use newest gcc found
         sint = lambda x: int(x) if x.isdigit() else 0
@@ -249,4 +254,3 @@ setup(
 )
 
 print('\n[setup.py request was successful.]')
-


### PR DESCRIPTION
Here are two changes that allow for installation on Apple Silicon computers:

1. `setup.py` looks in `/usr/local/bin/` for `gcc` if it detects macOS. This is where homebrew installs things on Intel Macs, but on Silicon, homebrew instead puts things in `/opt/homebrew/bin/` (see https://docs.brew.sh/FAQ#why-should-i-install-homebrew-in-the-default-location). I've changed `setup.py` to look there if `gcc` is not found in `/usr/local/bin/`.
2. `cython/sharp_utils.c` includes `immintrin.h`, which includes x86 instructions that are not implemented on Silicon. The functions in `sharp_utils.c` that would use these are already turned off with preprocessor directives, so I've done the same for the `#include <immintrin.h>` line.