### PR TITLE
Replace getsize with getbbox

### DIFF
--- a/pixell/enplot.py
+++ b/pixell/enplot.py
@@ -535,7 +535,7 @@ def draw_colorbar(crange, width, args):
 	labels, boxes = [], []
 	for val in crange:
 		labels.append(fmt % val)
-		boxes.append(font.getsize(labels[-1]))
+		boxes.append(font.getbbox(labels[-1])[-2:])
 	boxes = np.array(boxes,int)
 	lw, lh = np.max(boxes,0)
 	img    = PIL.Image.new("RGBA", (width, lh))
@@ -817,7 +817,7 @@ def draw_annotations(map, annots, args):
 			if font is None or size != font_size_prev:
 				font = cgrid.get_font(size)
 				font_size_prev = size
-			tbox = font.getsize(text)
+			tbox = font.getbbox(text)[-2:]
 			draw.text((x-tbox[0]/2, y-tbox[1]/2), text, color, font=font)
 		else:
 			raise NotImplementedError


### PR DESCRIPTION
Latest Pillow release (`v10`) has no `getsize` attribute and replace it with `getbbox`. Here we only keep the last two coordinates corresponding to width and height.

**The fix is backward compatible and also works with Pillow 9.5 (at least)**

Fix #225 