### PR TITLE
Set default value of OMP_NUM_THREADS to zero (and not None)

### DIFF
--- a/pixell/curvedsky.py
+++ b/pixell/curvedsky.py
@@ -7,7 +7,7 @@ from . import enmap, powspec, wcsutils, utils, bunch, cmisc
 # This must be done before importing ducc0 for the first time. Doing this
 # limits wasted memory from ducc allocating too big a thread pool. For computes
 # with many cores, this can save GBs of memory.
-utils.setenv("DUCC0_NUM_THREADS", utils.getenv("OMP_NUM_THREADS"), keep=True)
+utils.setenv("DUCC0_NUM_THREADS", utils.getenv("OMP_NUM_THREADS", 0), keep=True)
 import ducc0
 
 class ShapeError(Exception): pass


### PR DESCRIPTION
The `DUCC0_NUM_THREADS` env. variable is converted to `long int` within `ducc` (https://gitlab.mpcdf.mpg.de/mtr/ducc/-/blob/ducc0/src/ducc0/infra/threading.cc#L135) and passing the string "None" is actually "well" converted to zero (so to leave `ducc` finds and optimizes the number of threads) but it raises a kind of logic error (`Invalid argument`) since "None" is not an integer. On laptop where `OMP_NUM_THREADS` is not necessary set, all goes well with GNU C compiler (so no error) but the `clang` compiler (on mac for instance) is more strict and raises an error.