### PR TITLE
Fix alm2map 2d

### DIFF
--- a/pixell/curvedsky.py
+++ b/pixell/curvedsky.py
@@ -1241,7 +1241,7 @@ def analyse_geometry(shape, wcs, tol=1e-6):
 	# Flipped geometry
 	wshape, wwcs = flip_geometry(shape, wcs, flip)
 	# Get phi0 for the flipped geo
-	phi0 = wwcs.wcs_pix2world(0, 0, 0)[0]*utils.degree
+	phi0 = wcsutils.nobcheck(wwcs).wcs_pix2world(0, wshape[-2]//2, 0)[0]*utils.degree
 	# Check how we fit with a predefined ducc geometry
 	ducc_geo  = get_ducc_geo(wwcs, shape=wshape, tol=tol)
 	# If ducc_geo exists, then this map can either be used directly in

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.23.8
+current_version = 0.23.9
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.23.9
+current_version = 0.23.10
 commit = True
 tag = True
 


### PR DESCRIPTION
Fix a bug where on rare occasions, fullsky maps would end up rotated in RA after an alm2map operation. This was caused by wcs.pix2world returning nan when evaluated at the map edge when bounds checking is turned on. Fixed by both turning off bounds checks and by using the middle of the map in declination instead of the bottom.