### PR TITLE
Fix numpy 2.0 errors

### DIFF
--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -48,7 +48,10 @@ class ndmap(np.ndarray):
 	def __repr__(self):
 		return "ndmap(%s,%s)" % (np.asarray(self), wcsutils.describe(self.wcs))
 	def __str__(self): return repr(self)
-	def __array_wrap__(self, arr, context=None):
+	def __array_wrap__(self, arr, context=None, return_scalar=False):
+		# In the future need to support `return_scalar`, but that is seemingly
+		# undocumented and not actually supported in numpy 2.0? So for now we
+		# just ignore it.
 		if arr.ndim < 2: return arr
 		return ndmap(arr, self.wcs)
 	def __reduce__(self):

--- a/pixell/enplot.py
+++ b/pixell/enplot.py
@@ -542,6 +542,14 @@ def draw_colorbar(crange, width, args):
 	fmt  = "%g"
 	labels, boxes = [], []
 	for val in crange:
+		# Val could be a one-element array. In NumPy 1.25 this is not
+		# acceptable to string formatters.
+
+		try:
+			val = val[0]
+		except (TypeError, IndexError):
+			pass
+		
 		labels.append(fmt % val)
 		boxes.append(font.getbbox(labels[-1])[-2:])
 	boxes = np.array(boxes,int)

--- a/pixell/tilemap.py
+++ b/pixell/tilemap.py
@@ -71,7 +71,10 @@ class TileMap(np.ndarray):
 	def __repr__(self):
 		return "TileMap(%s,%s)" % (np.asarray(self), str(self.geometry))
 	def __str__(self): return repr(self)
-	def __array_wrap__(self, arr, context=None):
+	def __array_wrap__(self, arr, context=None, return_scalar=False):
+		# In the future need to support `return_scalar`, but that is seemingly
+		# undocumented and not actually supported in numpy 2.0? So for now we
+		# just ignore it.
 		return TileMap(arr, self.geometry)
 	def __getitem__(self, sel):
 		# Split sel into normal and wcs parts.

--- a/tests/test_pixell.py
+++ b/tests/test_pixell.py
@@ -1121,7 +1121,3 @@ class PixelTests(unittest.TestCase):
         assert m1c.geometry.nactive == 2
         assert np.allclose(m1c, 1)
 
-
-if __name__ == '__main__':
-    unittest.main()
-    test_sim_slice()


### PR DESCRIPTION
Fixes warnings raised when running numpy 2.0 and the test suite. Removes around 12'000 errors from the test suite.