### PR TITLE
Fix colormap registration

### DIFF
--- a/pixell/colorize.py
+++ b/pixell/colorize.py
@@ -169,7 +169,7 @@ def mpl_register(names=None):
 	if isinstance(names, basestring): names = [names]
 	for name in names:
 		cmap = to_mpl_colormap(name, schemes[name])
-		matplotlib.cm.register_cmap(name, cmap)
+		matplotlib.colormaps.register(cmap, name=name)
 
 def mpl_setdefault(name):
 	import matplotlib.pyplot


### PR DESCRIPTION
`matplotlib.cm.register_cmap` has been removed and `matplotlib.colormaps.register` has been around since almost 3 years (since version 3.5.0 of `matplotlib`). Not sure it is worth adding a backward compatible flag such as

```python
import matplotlib
if matplotlib.__version__ >= "3.5.0":
  matplotlib.colormaps.register(cmap, name=name)
else:
  matplotlib.cm.register_cmap(name, cmap)
```