### PR TITLE
Update from development repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,18 +74,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
+        uses: pypa/cibuildwheel@v2.19.1
         env:
           FC: gfortran-12
           CC: gcc-12
           MACOSX_DEPLOYMENT_TARGET: "13.0"
-        run: |
-          python -m pip install build
-          python -m build
 
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: dist/*.whl
+          path: ./wheelhouse/*.whl
 
   build_wheels_macos_arm:
     name: Build wheels on ${{ matrix.os }}
@@ -99,18 +97,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
+        uses: pypa/cibuildwheel@v2.19.1
         env:
           FC: gfortran-12
           CC: gcc-12
           MACOSX_DEPLOYMENT_TARGET: "14.0"
-        run: |
-          python -m pip install build
-          python -m build
 
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: dist/*.whl
+          path: ./wheelhouse/*.whl
 
 
   build_sdist:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: ./wheelhouse/*.whl
+          path: dist/*.whl
 
   build_wheels_macos_arm:
     name: Build wheels on ${{ matrix.os }}
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: ./wheelhouse/*.whl
+          path: dist/*.whl
 
 
   build_sdist:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ jobs:
         python: ["3.12", "3.11", "3.10"]
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       
@@ -32,15 +32,14 @@ jobs:
     name: "Run tests on MacOS"
     runs-on: macos-latest
     env:
-      #LDFLAGS: "-ld64" # For MacOS 13 and above (XCode CLT 15 and above.)
       CC: gcc-14
       CXX: gcc-14
       FC: gfortran-14
       DUCC0_NUM_THREADS: 2
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -113,9 +112,9 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.10'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
   test-macos:
     name: "Run tests on MacOS"
-    runs-on: macos-15
+    runs-on: macos-15-arm64
     env:
       #LDFLAGS: "-ld64" # For MacOS 13 and above (XCode CLT 15 and above.)
       CC: gcc-14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,10 @@ jobs:
     name: "Run tests on MacOS"
     runs-on: macos-12
     env:
-      # LDFLAGS: "-ld64" # For MacOS 13 and above (XCode CLT 15 and above.)
-      CC: gcc-13
-      CXX: gcc-13
-      FC: gfortran-13
+      LDFLAGS: "-ld64" # For MacOS 13 and above (XCode CLT 15 and above.)
+      CC: gcc-12
+      CXX: gcc-12
+      FC: gfortran-12
       DUCC0_NUM_THREADS: 2
 
     steps:
@@ -76,8 +76,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
         env:
-          FC: gfortran-13
-          CC: gcc-13
+          FC: gfortran-12
+          CC: gcc-12
           MACOSX_DEPLOYMENT_TARGET: "13.0"
 
       - uses: actions/upload-artifact@v4
@@ -99,8 +99,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
         env:
-          FC: gfortran-13
-          CC: gcc-13
+          FC: gfortran-12
+          CC: gcc-12
           MACOSX_DEPLOYMENT_TARGET: "14.0"
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,9 @@ jobs:
     runs-on: macos-12
     env:
       # LDFLAGS: "-ld64" # For MacOS 13 and above (XCode CLT 15 and above.)
-      CC: gcc-12
-      CXX: gcc-12
-      FC: gfortran-12
+      CC: gcc-13
+      CXX: gcc-13
+      FC: gfortran-13
       DUCC0_NUM_THREADS: 2
 
     steps:
@@ -76,8 +76,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
         env:
-          FC: gfortran-12
-          CC: gcc-12
+          FC: gfortran-13
+          CC: gcc-13
           MACOSX_DEPLOYMENT_TARGET: "13.0"
 
       - uses: actions/upload-artifact@v4
@@ -99,8 +99,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
         env:
-          FC: gfortran-12
-          CC: gcc-12
+          FC: gfortran-13
+          CC: gcc-13
           MACOSX_DEPLOYMENT_TARGET: "14.0"
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,11 +74,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.1
         env:
           FC: gfortran-12
           CC: gcc-12
           MACOSX_DEPLOYMENT_TARGET: "13.0"
+        run: |
+          python -m pip install build
+          python -m build
 
       - uses: actions/upload-artifact@v4
         with:
@@ -97,11 +99,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.1
         env:
           FC: gfortran-12
           CC: gcc-12
           MACOSX_DEPLOYMENT_TARGET: "14.0"
+        run: |
+          python -m pip install build
+          python -m build
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     name: "Run tests on MacOS"
     runs-on: macos-12
     env:
-      LDFLAGS: "-ld64" # For MacOS 13 and above (XCode CLT 15 and above.)
+      #LDFLAGS: "-ld64" # For MacOS 13 and above (XCode CLT 15 and above.)
       CC: gcc-12
       CXX: gcc-12
       FC: gfortran-12

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
   test-macos:
     name: "Run tests on MacOS"
-    runs-on: macos-15-arm64
+    runs-on: macos-latest
     env:
       #LDFLAGS: "-ld64" # For MacOS 13 and above (XCode CLT 15 and above.)
       CC: gcc-14
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [macos-14]
+        os: [macos-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.12", "3.11", "3.10", "3.9"]
+        python: ["3.12", "3.11", "3.10"]
 
     steps:
       - uses: actions/checkout@v1
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install Dependencies (MacOS)
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,12 +30,12 @@ jobs:
 
   test-macos:
     name: "Run tests on MacOS"
-    runs-on: macos-12
+    runs-on: macos-15
     env:
       #LDFLAGS: "-ld64" # For MacOS 13 and above (XCode CLT 15 and above.)
-      CC: gcc-12
-      CXX: gcc-12
-      FC: gfortran-12
+      CC: gcc-14
+      CXX: gcc-14
+      FC: gfortran-14
       DUCC0_NUM_THREADS: 2
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,17 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	pip install .
+
+
+# Symlink-based alternative setup below. Not intended for general use
+# Standard meson build
+SHELL=/bin/bash
+.PHONY: build inline
+inline: build
+	(shopt -s nullglob; cd pixell; rm -f *.so; ln -s ../build/*.so ../build/*.dylib .)
+build: build/build.ninja
+	(cd build; meson compile)
+build/build.ninja:
+	rm -rf build
+	mkdir build
+	meson setup build

--- a/cython/cmisc.pyx
+++ b/cython/cmisc.pyx
@@ -31,7 +31,7 @@ def alm2cl(ainfo, alm, alm2=None):
 	# I used to flatten here to make looping simple, but that caused a copy to be made
 	# when combined with np.broadcast. So instead I will use manual raveling
 	pshape = alm.shape[:-1]
-	npre   = int(np.product(pshape))
+	npre   = int(np.prod(pshape))
 	cdef float[::1]  cl_single_sp, alm_single_sp1, alm_single_sp2
 	cdef double[::1] cl_single_dp, alm_single_dp1, alm_single_dp2
 	cdef int64_t[::1] mstart = np.ascontiguousarray(ainfo.mstart).view(np.int64)

--- a/cython/distances_core.c
+++ b/cython/distances_core.c
@@ -15,7 +15,7 @@ int xoffs[8] = {-1, +1,  0,  0, +1, -1, +1, -1 };
 double wall_time() { struct timeval tv; gettimeofday(&tv,0); return tv.tv_sec + 1e-6*tv.tv_usec; }
 int max(int a, int b) { return a > b ? a : b; }
 int min(int a, int b) { return a < b ? a : b; }
-int compar_int(int * a, int * b) { return *a-*b; }
+int compar_int(const void * a, const void * b) { return *(int*)a-*(int*)b; }
 int wrap1(int a, int n) { return a < 0 ? a+n : a >= n ? a-n : a; }
 
 // The simple functions are too slow to serve as the basis for a distance transform.

--- a/fortran/interpol.F90
+++ b/fortran/interpol.F90
@@ -1,6 +1,6 @@
 module fortran
 
-	private :: map_border, calc_weights
+	!private :: map_border, calc_weights
 
 contains
 

--- a/meson.build
+++ b/meson.build
@@ -45,6 +45,8 @@ incdir_f2py = run_command(
 run_command('make', '-C', 'fortran', check: true)
 
 fortran_include = include_directories(incdir_numpy, incdir_f2py)
+add_project_arguments('-Wno-tabs', language : 'fortran')
+add_project_arguments('-Wno-conversion', language : 'fortran')
 
 fortran_sources = {
     'fortran/interpol_32.f90': '_interpol_32',

--- a/meson.build
+++ b/meson.build
@@ -89,7 +89,7 @@ helper_sources = {
 linkables = []
 
 foreach source_name, module_name : helper_sources
-    linkables += shared_library(
+    linkables += static_library(
         module_name,
         source_name,
         install: true,

--- a/pixell/aberration.py
+++ b/pixell/aberration.py
@@ -116,7 +116,7 @@ class Aberrator:
 		nthread = int(utils.fallback(utils.getenv("OMP_NUM_THREADS",nthread),0))
 		# 1. Calculate the aberration field. These are tiny
 		alm_dpos = calc_boost_field(-beta, dir, nthread=nthread)
-		# 2. Evaluate these on our target geometry. Hardcoded float64 because of get_deflected_angles
+		# 2. Evaluate these on our target geometry.
 		deflect = enmap.zeros(alm_dpos.shape[:-1]+shape[-2:], wcs, coord_dtype)
 		curvedsky.alm2map(alm_dpos.astype(coord_ctype, copy=False), deflect, spin=1, nthread=nthread)
 		# 3. Calculate the offset angles.

--- a/pixell/curvedsky.py
+++ b/pixell/curvedsky.py
@@ -1238,7 +1238,7 @@ def analyse_geometry(shape, wcs, tol=1e-6):
 	# TODO: Pseudo-cylindrical projections can be handled with standard ducc synthesis,
 	# so ideally our check would be less stringent than this. Supporinting them requires
 	# more work, so will just do it with the general interface for now.
-	separable = wcsutils.is_cyl(wcs)
+	separable = wcsutils.is_separable(wcs)
 	divides   = utils.hasoff(360/np.abs(wcs.wcs.cdelt[0]), 0, tol=tol)
 	if not separable or not divides:
 		# Not cylindrical or ra does not evenly divide the sky

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -1804,7 +1804,7 @@ def downgrade_geometry(shape, wcs, factor):
 	supports integer factors."""
 	factor = np.full(2, 1, dtype=int)*factor
 	oshape = tuple(shape[-2:]//factor)
-	owcs   = wcsutils.scale(wcs, 1.0/factor)
+	owcs   = wcsutils.scale(wcs, 1.0/factor, rowmajor=True)
 	return oshape, owcs
 
 def upgrade_geometry(shape, wcs, factor):

--- a/pixell/enplot.py
+++ b/pixell/enplot.py
@@ -915,7 +915,7 @@ def draw_ellipse(image, bounds, width=1, outline='white', antialias=1):
 		draw.ellipse([a[0],a[1],b[0],b[1]], fill=fill)
 	# downsample the mask using PIL.Image.LANCZOS 
 	# (a high-quality downsampling filter).
-	mask = mask.resize(esize, PIL.Image.LANCZOS)
+	mask = mask.resize(tuple(esize), PIL.Image.LANCZOS)
 	# paste outline color to input image through the mask
 	image.paste(outline, tuple(bounds[:2]-width), mask=mask)
 

--- a/pixell/fft.py
+++ b/pixell/fft.py
@@ -397,8 +397,8 @@ def resample_fft(fa, n, out=None, axes=-1, norm=1, op=lambda a,b:b):
 			c = min(fa.shape[ax], oshape[ax])
 			if I[ai] == 0: sel[ax] = slice(0,c//2)
 			else:          sel[ax] = slice(-(c-c//2),None)
-	sel = tuple(sel)
-	transfer(out[sel], fa[sel], norm, op)
+		sel = tuple(sel)
+		transfer(out[sel], fa[sel], norm, op)
 	return out
 
 def fft_flat(tod, ft, nthread=1, axes=[-1], flags=None, _direction="FFTW_FORWARD"):

--- a/pixell/pointsrcs.py
+++ b/pixell/pointsrcs.py
@@ -81,7 +81,7 @@ def sim_objects(shape, wcs, poss, amps, profile, prof_ids=None, omap=None, vmin=
 	sources will have been added (or maxed etc. depending on op) into the map.
 	Otherwise, the only signal in the map will be the objects."""
 	dtype = np.float32 # C extension only supports this dtype
-	if separable == "auto": separable = wcsutils.is_cyl(wcs)
+	if separable == "auto": separable = wcsutils.is_separable(wcs)
 	# Object positions
 	obj_decs = np.asanyarray(poss[0], dtype=dtype, order="C")
 	obj_ras  = np.asanyarray(poss[1], dtype=dtype, order="C")
@@ -149,7 +149,7 @@ def radial_sum(map, poss, bins, oprofs=None, separable="auto",
 	Returns the resulting profiles. If oprof was specified, then the same object will
 	be returned (after being updated of course)."""
 	dtype = np.float32 # C extension only supports this dtype
-	if separable == "auto": separable = wcsutils.is_cyl(map.wcs)
+	if separable == "auto": separable = wcsutils.is_separable(map.wcs)
 	# Object positions
 	obj_decs = np.asanyarray(poss[0], dtype=dtype, order="C")
 	obj_ras  = np.asanyarray(poss[1], dtype=dtype, order="C")
@@ -264,7 +264,7 @@ def sim_srcs_python(shape, wcs, srcs, beam, omap=None, dtype=None, nsigma=5, rma
 
 	The source simulation is sped up by using a source lookup grid.
 	"""
-	if separable == "auto": separable = wcsutils.is_cyl(wcs)
+	if separable == "auto": separable = wcsutils.is_separable(wcs)
 	if omap is None: omap = enmap.zeros(shape, wcs, dtype)
 	ishape = omap.shape
 	omap   = omap.preflat

--- a/pixell/uharm.py
+++ b/pixell/uharm.py
@@ -138,7 +138,7 @@ class UHT:
 			return curvedsky.harm2profile(harm, r)
 	def lprof2hprof(self, lprof):
 		if self.mode == "flat":
-			return enmap.enmap(utils.interpol(lprof, self.l[None], order=1, mode="constant"), self.wcs, copy=False)
+			return enmap.enmap(utils.interpol(lprof, self.l[None], order=1, border="constant"), self.wcs, copy=False)
 		else:
 			if lprof.shape[-1] >= self.lmax+1:
 				return lprof[...,:self.lmax+1]

--- a/pixell/utils.py
+++ b/pixell/utils.py
@@ -3091,6 +3091,10 @@ def ascomplex(arr):
 	arr = np.asanyarray(arr)
 	return arr.astype(complex_dtype(arr.dtype))
 
+def astuple(num_or_list):
+	try: return tuple(num_or_list)
+	except TypeError: return (num_or_list,)
+
 # Conjugate gradients
 
 def default_M(x):     return np.copy(x)
@@ -3326,6 +3330,10 @@ def setenv(name, value, keep=False):
 	if   name in os.environ and keep: return
 	elif name in os.environ and value is None: del os.environ[name]
 	elif value is not None: os.environ[name] = str(value)
+
+def getaddr(a):
+	"""Get the address of the start of a"""
+	return a.__array_interface__["data"][0]
 
 def zip2(*args):
 	"""Variant of python's zip that calls next() the same number of times on

--- a/pixell/utils.py
+++ b/pixell/utils.py
@@ -523,7 +523,7 @@ def dedup(a):
 	return a[np.concatenate([[True],a[1:]!=a[:-1]])]
 
 def interpol(arr, inds, out=None, mode="spline", border="nearest",
-		order=3, cval=0.0, epsilon=None):
+		order=3, cval=0.0, epsilon=None, ip=None):
 	"""Given an array arr[{x},{y}] and a list of float indices into a,
 	inds[len(y),{z}], returns interpolated values at these positions as [{x},{z}].
 
@@ -567,8 +567,9 @@ def interpol(arr, inds, out=None, mode="spline", border="nearest",
 	arr  = np.asanyarray(arr)
 	inds = np.asanyarray(inds)
 	npre = arr.ndim - len(inds)
-	ip   = interpolator(arr, npre, mode=mode, border=border, order=order,
-			cval=cval, epsilon=epsilon)
+	if ip is None:
+		ip = interpolator(arr, npre, mode=mode, border=border, order=order,
+				cval=cval, epsilon=epsilon)
 	return ip(inds, out=out)
 
 def interpolator(arr, npre=0, mode="spline", border="nearest", order=3, cval=0.0,

--- a/pixell/utils.py
+++ b/pixell/utils.py
@@ -306,6 +306,12 @@ def deslope(d, w=1, inplace=False, axis=-1, avg=np.mean):
 			di -= np.arange(di.size)*(avg(di[-w:])-avg(di[:w]))/(di.size-1)+avg(di[:w])
 	return d
 
+def argmax(arr):
+	"""Multidimensional argmax. Returns a tuple indexing the full array
+	instead of just a number indexing the flattened array like np.argmax does"""
+	arr = np.asanyarray(arr)
+	return np.unravel_index(np.argmax(arr), arr.shape)
+
 def ctime2mjd(ctime):
 	"""Converts from unix time to modified julian date."""
 	return np.asarray(ctime)/86400. + 40587.0

--- a/pixell/wcsutils.py
+++ b/pixell/wcsutils.py
@@ -19,42 +19,101 @@ try: basestring
 except: basestring = str
 def streq(x, s): return isinstance(x, basestring) and x == s
 
-# The origin argument used in the wcs pix<->world routines seems to
-# have to be 1 rather than the 0 one would expect. For example,
-# if wcs is CAR(crval=(0,0),crpix=(0,0),cdelt=(1,1)), then
-# pix2world(0,0,1) is (0,0) while pix2world(0,0,0) is (-1,-1).
+# Geometry construction redesign
 #
-# No! the problem is that everythin in the fits header counts from 1,
-# so the default crpix should be (1,1), not (0,0). With
-# CAR(crval(0,0),crpix(1,1),cdelt(1,1)) we get
-# pix2world(1,1,1) = (0,0) and pix2world(0,0,0) = (0,0)
+# The old approach was build around the reference point. The idea was that
+# this point would always be a pixel center, no matter which coutout of
+# the sky one was looking at. The problem with this approach is that it doesn't
+# generalize to downgrading, and it clashes with finer detalies such as
+# distinguishing between CC and Fejer1, which care about the pixel alignment
+# at the poles, not the equator where the reference point usually is.
+#
+# The new approach will proceed in three steps:
+# 1. Specify the projection (ctype, crval) without any pixel details
+# 2. Turn it into a full-sky pixelization (crpix, cdelt). This could
+#    be done by specifying ny,nx or the resolution. We could here
+#    issue a warning or exception if the sky isn't evenly tiled.
+#    This part would care about sub-specifiers like :cc or :fejer1
+# 3. Crop this to cover the target area
+#
+# These can all be handled in separate functions. The output from step
+# 1 would be a wcs with default crpix and cdelt values.
+#
+# Problems:
+# 1. Currently pixelization can't handle all of these:
+#    * Fix left side but allow right side to float
+#    * Fix right side but allow left side to float
+#    * Fix both sides, but allow total width to float
+#    Right now the first two are supported, but not the last.
+#    For example, for CEA we can't expect a reasonable resolution
+#    to reach the poles with a senible pixel offset, but we want to
+#    at least make things symmetric around the equator. There's a choice
+#    between trying to get a pixel edge as close to the poles as possible
+#    or trying to get a pixel center as close to the poles as possible.
+#    These could be written as hh adjust and 00 adjust, but hard to fit
+#    this in currently.
+# 2. Some projections have extra parameters, like CEA with lambda and
+#    ZEA where one might want to be locally conformal. The approach where
+#    one first builds the fullsky geometry and only later worried about
+#    restricting it to a part of the sky clashes with this. Can support it,
+#    but is it a good idea to do it automatically?
 
-# Useful stuff to be able to do:
-#  * Create a wcs from (point,res)
-#  * Create a wcs from (box,res)
-#  * Create a wcs from (box,shape)
-#  * Create a wcs from (point,res,shape)
-# Can support this by taking arguments:
-#  pos: point[2] or box[2,2], mandatory
-#  res: num or [2], optional
-#  shape: [2], optional
-# In cases where shape is not specified, the implied
-# shape can be recovered from the wcs and a box by computing
-# the pixel coordinates of the corners. So we don't need to return
-# it.
+def projection(system, crval=None):
+	"""Generate a pixelization-agnostic wcs"""
+	system = system.lower()
+	if crval is None: crval = default_crval(system)
+	else: crval = np.zeros(2)+crval
+	if system in ["", "plain"]: return explicit(crval=crval)
+	return explicit(ctype=["RA---"+system.upper(), "DEC--"+system.upper()], crval=crval)
 
-#  1. Construct wcs from box, res (and return shape?)
-#  2. Construct wcs from box, shape
-#  3. Construct wcs from point, res (this is the most primitive version)
-
-deg2rad = np.pi/180
-rad2deg = 1/deg2rad
+def pixelization(pwcs, shape=None, res=None, variant=None):
+	"""Add pixel information to a wcs, returning a full-sky geometry,
+	or as close to that as the projection allows."""
+	# This is the hard part. Many projections have invalid areas, and
+	# some have infinite size. May just have to handle the cases one by
+	# one instead of trying to be general
+	system   = get_proj(pwcs)
+	extent   = default_extent(system)
+	variant  = variant or default_variant(system)
+	offs     = parse_variant(variant)
+	periodic = is_periodic(system)
+	# We will now split our extent into pixels. Find the intermediate
+	# coordinates of the first and last pixel center along each axis
+	if shape is None:
+		res = expand_res(res)
+		ra1, ra2, nx = pixelize_1d(extent[0], res=res[0],  offs=offs[0], periodic=periodic[0])
+		dec1,dec2,ny = pixelize_1d(extent[1], res=res[1],  offs=offs[1], periodic=periodic[1])
+	elif res is None:
+		ra1, ra2, nx = pixelize_1d(extent[0], n=shape[-2], offs=offs[0], periodic=periodic[0])
+		dec1,dec2,ny = pixelize_1d(extent[1], n=shape[-2], offs=offs[1], periodic=periodic[0])
+	else:
+		raise ValueError("Either res or shape must be given to build a pixelization")
+	# Now that we have the intermediate coordinates of our endpoints, we
+	# can calculate cdelt and crpix
+	owcs  = pwcs.deepcopy()
+	owcs.wcs.cdelt = [(ra2-ra1)/(nx-1), (dec2-dec1)/(ny-1)]
+	owcs.wcs.crpix = [1+(pwcs.wcs.crval[0]-ra1)/owcs.wcs.cdelt[0],1+(pwcs.wcs.crval[1]-dec1)/owcs.wcs.cdelt[1]]
+	return (ny,nx), owcs
 
 def explicit(naxis=2, **args):
 	wcs = WCS(naxis=naxis)
 	for key in args:
 		setattr(wcs.wcs, key, args[key])
 	return wcs
+
+def expand_res(res, signs=None, flip=False):
+	"""If res is not None, expand it to length 2. If it wasn't already
+	length 2, the RA sign will be inverted. If flip is True, the res order
+	will be flipped before expanding"""
+	if res is None: return res
+	# Bleh, compensate for later flip
+	if signs is None: signs = [1,-1] if flip else [-1,1]
+	res = np.atleast_1d(res)
+	assert res.ndim == 1, "Invalid res shape"
+	assert len(res) <= 2, "Invalid res length"
+	if flip: res, signs = res[::-1], signs[::-1]
+	if res.size == 1: res = np.array(signs)*res[0]
+	return res
 
 def describe(wcs):
 	"""Since astropy.wcs.WCS objects do not have a useful
@@ -104,13 +163,21 @@ def is_plain(wcs):
 
 def is_cyl(wcs):
 	"""Returns True if the wcs represents a cylindrical coordinate system"""
-	return get_proj(wcs) in ["cyp","cea","car","mer"] and wcs.wcs.crval[1] == 0
+	return get_proj(wcs) in ["cyp","cea","car","mer"]
+
+def is_separable(wcs):
+	return is_cyl(wcs) and wcs.wcs.crval[1] == 0
 
 def get_proj(wcs):
 	if isinstance(wcs, str): return wcs
 	else:
 		toks = wcs.wcs.ctype[0].split("-")
 		return toks[-1].lower() if len(toks) >= 2 else ""
+
+def parse_system(system, variant=None):
+	toks = system.split(":")
+	if len(toks) > 1: return toks[0].lower(), toks[1]
+	else: return toks[0].lower(), variant
 
 def scale(wcs, scale=1, rowmajor=False, corner=False):
 	"""Scales the linear pixel density of a wcs by the given factor, which can be specified
@@ -126,17 +193,197 @@ def scale(wcs, scale=1, rowmajor=False, corner=False):
 		wcs.wcs.crpix += 0.5
 	return wcs
 
-def expand_res(res, default_dirs=[1,-1]):
-	res = np.atleast_1d(res)
-	assert res.ndim == 1, "Invalid res shape"
-	if res.size == 1:
-		return np.array(default_dirs)*res
+#def expand_res(res, default_dirs=[1,-1]):
+#	res = np.atleast_1d(res)
+#	assert res.ndim == 1, "Invalid res shape"
+#	if res.size == 1:
+#		return np.array(default_dirs)*res
+#	else:
+#		return res
+
+###########################
+#### Helper functions #####
+###########################
+
+def is_azimuthal(system): return system.lower() in ["arc", "zea", "sin", "tan", "azp", "slp", "stg", "zpn", "air"]
+
+def default_crval(system):
+	if is_azimuthal(system): return [0,90]
+	else: return [0,0]
+
+def default_extent(system):
+	"""Return the horizontal and vertical extent of the full sky in degrees.
+	For some systems the full sky is not representable, in which case a
+	reasonable compromise is returned"""
+	system = system.lower()
+	if   system in ["", "plain"]: return [1,1]
+	# Cylindrical
+	if   system == "car": return [360,180]
+	elif system == "cea": return [360,360/np.pi]
+	elif system == "mer": return [360,360] # traditional dec range gives square map
+	# Zenithal
+	elif system == "arc": return [360,360]
+	elif system == "zea": return [720/np.pi,720/np.pi]
+	elif system == "sin": return [360/np.pi,360/np.pi] # only orthographic supported
+	elif system == "tan": return [360,360] # goes down to 0.158° above the horizon
+	# Pseudo-cyl
+	elif system == "mol": return [720*2**0.5/np.pi,360*2**0.5/np.pi]
+	elif system == "ait": return [720*2**0.5/np.pi,360*2**0.5/np.pi]
+	else: raise ValueError("Unsupported system '%s'" % str(system))
+
+def default_variant(system):
+	system = system.lower()
+	return "fejer1" if system in ["car","plain",""] else "any"
+
+def extent2bounds(extent): return [[-e/h,e/h] for e in extent]
+
+def is_periodic(system):
+	system = system.lower()
+	if is_azimuthal(system) or system in ["", "plain"]:
+		return [False,False]
 	else:
-		return res
+		return [True,False]
+
+def parse_variant(name):
+	name = name.lower()
+	if   name == "safe":   rule = "hh,hh" # fully-downgrade safe. What fejer1 should have been
+	elif name == "fejer1": rule = "00,hh" # stays SHTable after downgrade, but not pix-comp with raw @ that res
+	elif name == "cc":     rule = "00,00" # what we used for pre-DR6. Cannot SHT after downgrade
+	elif name == "any":    rule = "**,**"
+	else: rule = name
+	toks = rule.split(",")
+	if len(toks) != 2 or len(toks[0]) != 2 or len(toks[1]) != 2:
+		raise ValueError("Could not recognize pixelization variant '%s'" % (str(name)))
+	left  = {"0": 0, "h": 0.5, "*": None}
+	right = {"0": 0, "h":-0.5, "*": None}
+	try:
+		return [[left[tok[0]],right[tok[1]]] for tok in toks]
+	except KeyError:
+		raise ValueError("Invalid character in rule '%s'" % str(rule))
+
+class PixelizationError(Exception): pass
+
+def pixelize_1d(w, n=None, res=None, offs=None, periodic=False, adjust=False, sign=1, tol=1e-6, eps=1e-6):
+	"""Figure out how to align pixels along an interval w long such
+	that there are either n pixels or the resolution is res, and with
+	the given pixel offsets from the edges. Returns the coordinates of
+	the center of the first and last pixel."""
+	# FIXME: This is a bit poorly thought out. The concept of being
+	# able to adjust the range and that of having wildcard edges should
+	# be separate, but the way we've done things now there's no room in
+	# parse_variant to say something like "0h" but adjustable. For now
+	# I just have to hardcode that "**" means "00" but adjustable.
+	o1, o2 = offs if offs is not None else (None, None)
+	if res is not None:
+		if res < 0: res, sign = -res, -sign
+		if o1 is None and o2 is None:
+			o1 = o2 = 0
+			adjust = True
+		if o2 is None:
+			# Add a tiny number to avoid having a rounding discontinuity for common values
+			# off w, res and o1
+			n   = int(w/res+1-o1+eps)
+		elif o1 is None:
+			n   = int(w/res+1+o2+eps)
+		else:
+			# Both given! Can we satisfy requirement?
+			nf = w/res+1-(o1-o2)
+			n  = int(nf+eps)
+			if adjust:
+				# We're free to redefine w so things work
+				w = (n+(o1+o2)-1)*res
+			else:
+				# Complain if the resolution and offsets are incompatible
+				if not np.abs(n-nf)<tol:
+					raise PixelizationError("Resolution %g does not evenly divide extent %g with offsets [%g,%g]" %
+						(res, w, o1, o2))
+	else:
+		if o1 is None: o1 =  0.5
+		if o2 is None: o2 = -0.5
+		res = w/(n-1+o1-o2)
+	# Finish up
+	if o1 is not None:
+		ra1 = -w/2+o1*res
+		ra2 = ra1+(n-1)*res
+	else:
+		ra2 = +w/2+o2*res
+		ra1 = ra2 - (n-1)*res
+	# If this axis is periodic, then the last point could be equal to the first,
+	# depending on the pixelization
+	if periodic and np.allclose(ra2-ra1,w):
+		ra2 -= res
+		n   -= 1
+	# Apply any sign
+	ra1 *= sign
+	ra2 *= sign
+	return ra1, ra2, n
+
+def fix_wcs(wcs, axis=0):
+	"""Returns a new WCS object which has had the reference pixel moved to the
+	middle of the possible pixel space."""
+	res = wcs.deepcopy()
+	# Find the center ra manually: mean([crval - crpix*cdelt, crval + (-crpix+shape)*cdelt])
+	#  = crval + (-crpix+shape/2)*cdelt
+	# What pixel does this correspond to?
+	#  crpix2 = crpix + (crval2-crval)/cdelt
+	# But that requires shape. Can we do without it? Yes, let's use the
+	# biggest possible shape. n = 360/cdelt
+	n = abs(360/wcs.wcs.cdelt[axis])
+	delta_ra  = wcs.wcs.cdelt[axis]*(n/2-wcs.wcs.crpix[axis])
+	delta_pix = delta_ra/wcs.wcs.cdelt[axis]
+	res.wcs.crval[axis] += delta_ra
+	res.wcs.crpix[axis] += delta_pix
+	repr(res.wcs) # wcs not properly updated if I don't do this
+	return res
+
+def fix_cdelt(wcs):
+	"""Return a new wcs with pc and cd replaced by cdelt"""
+	owcs = wcs.deepcopy()
+	if wcs.wcs.has_cd():
+		del owcs.wcs.cd, owcs.wcs.pc
+		owcs.wcs.cdelt *= np.diag(wcs.wcs.cd)
+	elif wcs.wcs.has_pc():
+		del owcs.wcs.cd, owcs.wcs.pc
+		owcs.wcs.cdelt *= np.diag(wcs.wcs.pc)
+	return owcs
+
+# The functions below are used to implement the old
+# patch-oriented geometry functions.
+
+# The origin argument used in the wcs pix<->world routines seems to
+# have to be 1 rather than the 0 one would expect. For example,
+# if wcs is CAR(crval=(0,0),crpix=(0,0),cdelt=(1,1)), then
+# pix2world(0,0,1) is (0,0) while pix2world(0,0,0) is (-1,-1).
+#
+# No! the problem is that everythin in the fits header counts from 1,
+# so the default crpix should be (1,1), not (0,0). With
+# CAR(crval(0,0),crpix(1,1),cdelt(1,1)) we get
+# pix2world(1,1,1) = (0,0) and pix2world(0,0,0) = (0,0)
+
+# Useful stuff to be able to do:
+#  * Create a wcs from (point,res)
+#  * Create a wcs from (box,res)
+#  * Create a wcs from (box,shape)
+#  * Create a wcs from (point,res,shape)
+# Can support this by taking arguments:
+#  pos: point[2] or box[2,2], mandatory
+#  res: num or [2], optional
+#  shape: [2], optional
+# In cases where shape is not specified, the implied
+# shape can be recovered from the wcs and a box by computing
+# the pixel coordinates of the corners. So we don't need to return
+# it.
+
+#  1. Construct wcs from box, res (and return shape?)
+#  2. Construct wcs from box, shape
+#  3. Construct wcs from point, res (this is the most primitive version)
 
 # I need to update this to work better with full-sky stuff.
 # Should be easy to construct something that's part of a
 # clenshaw-curtis or fejer sky.
+
+deg2rad = np.pi/180
+rad2deg = 1/deg2rad
 
 def plain(pos, res=None, shape=None, rowmajor=False, ref=None):
 	"""Set up a plain coordinate system (non-cyclical)"""
@@ -297,32 +544,3 @@ def _apply_zenithal_ref(w, ref):
 
 def angdist(lon1,lat1,lon2,lat2):
 	return np.arccos(np.cos(lat1)*np.cos(lat2)*(np.cos(lon1)*np.cos(lon2)+np.sin(lon1)*np.sin(lon2))+np.sin(lat1)*np.sin(lat2))
-
-def fix_wcs(wcs, axis=0):
-	"""Returns a new WCS object which has had the reference pixel moved to the
-	middle of the possible pixel space."""
-	res = wcs.deepcopy()
-	# Find the center ra manually: mean([crval - crpix*cdelt, crval + (-crpix+shape)*cdelt])
-	#  = crval + (-crpix+shape/2)*cdelt
-	# What pixel does this correspond to?
-	#  crpix2 = crpix + (crval2-crval)/cdelt
-	# But that requires shape. Can we do without it? Yes, let's use the
-	# biggest possible shape. n = 360/cdelt
-	n = abs(360/wcs.wcs.cdelt[axis])
-	delta_ra  = wcs.wcs.cdelt[axis]*(n/2-wcs.wcs.crpix[axis])
-	delta_pix = delta_ra/wcs.wcs.cdelt[axis]
-	res.wcs.crval[axis] += delta_ra
-	res.wcs.crpix[axis] += delta_pix
-	repr(res.wcs) # wcs not properly updated if I don't do this
-	return res
-
-def fix_cdelt(wcs):
-	"""Return a new wcs with pc and cd replaced by cdelt"""
-	owcs = wcs.deepcopy()
-	if wcs.wcs.has_cd():
-		del owcs.wcs.cd, owcs.wcs.pc
-		owcs.wcs.cdelt *= np.diag(wcs.wcs.cd)
-	elif wcs.wcs.has_pc():
-		del owcs.wcs.cd, owcs.wcs.pc
-		owcs.wcs.cdelt *= np.diag(wcs.wcs.pc)
-	return owcs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ['meson-python', 'numpy', 'cython', 'versioneer[toml]', 'build']
 
 [project]
 name = 'pixell'
-version = "0.26.0"
+version = "0.26.1"
 description = "A rectangular pixel map manipulation and harmonic analysis library derived from Sigurd Naess' enlib."
 readme = 'README.rst'
 requires-python = '>=3.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ['meson-python', 'numpy', 'cython', 'versioneer[toml]', 'build']
 
 [project]
 name = 'pixell'
-version = "0.27.0"
+version = "0.27.1"
 description = "A rectangular pixel map manipulation and harmonic analysis library derived from Sigurd Naess' enlib."
 readme = 'README.rst'
 requires-python = '>=3.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ['meson-python', 'numpy', 'cython', 'versioneer[toml]', 'build']
 
 [project]
 name = 'pixell'
-version = "0.26.2"
+version = "0.27.0"
 description = "A rectangular pixel map manipulation and harmonic analysis library derived from Sigurd Naess' enlib."
 readme = 'README.rst'
 requires-python = '>=3.9'

--- a/tests/test_pixell.py
+++ b/tests/test_pixell.py
@@ -137,7 +137,7 @@ def get_geometries(yml_section):
     geos = {}
     for g in yml_section:
         if g['type']=='fullsky':
-            geos[g['name']] = enmap.fullsky_geometry(res=np.deg2rad(g['res_arcmin']/60.),proj=g['proj'])
+            geos[g['name']] = enmap.fullsky_geometry(res=np.deg2rad(g['res_arcmin']/60.),proj=g['proj'],variant="CC")
         elif g['type']=='pickle':
             geos[g['name']] = pickle.load(open(DATA_PREFIX+"%s"%g['filename'],'rb'))
         else:
@@ -198,7 +198,7 @@ def get_extraction_test_results(yaml_file):
 lens_version = '071123'
 
 def get_offset_result(res=1.,dtype=np.float64,seed=1):
-    shape,wcs  = enmap.fullsky_geometry(res=np.deg2rad(res))
+    shape,wcs  = enmap.fullsky_geometry(res=np.deg2rad(res), variant="CC")
     shape = (3,) + shape
     obs_pos = enmap.posmap(shape, wcs)
     np.random.seed(seed)
@@ -207,7 +207,7 @@ def get_offset_result(res=1.,dtype=np.float64,seed=1):
     return obs_pos,grad,raw_pos
 
 def get_lens_result(res=1.,lmax=400,dtype=np.float64,seed=1):
-    shape,wcs  = enmap.fullsky_geometry(res=np.deg2rad(res))
+    shape,wcs  = enmap.fullsky_geometry(res=np.deg2rad(res), variant="CC")
     shape = (3,) + shape
     # ells = np.arange(lmax)
     ps_cmb,ps_lens = powspec.read_camb_scalar(DATA_PREFIX+"test_scalCls.dat")
@@ -485,7 +485,7 @@ class PixelTests(unittest.TestCase):
         print("Testing full sky geometry...")
         test_res_arcmin = 0.5
         shape,wcs = enmap.fullsky_geometry(res=np.deg2rad(test_res_arcmin/60.),proj='car')
-        assert shape[0]==21601 and shape[1]==43200
+        assert shape[0]==21600 and shape[1]==43200
         assert abs(enmap.area(shape,wcs) - 4*np.pi) < 1e-6
 
     def test_pixels(self):
@@ -633,8 +633,8 @@ class PixelTests(unittest.TestCase):
         shape2,wcs2 = enmap.fullsky_geometry(res=np.deg2rad(6/60.),proj='car')
         shape3,wcs3 = enmap.fullsky_geometry(res=np.deg2rad(24/60.),proj='car')
         imap = enmap.ones(shape,wcs)
-        omap2 = enmap.project(imap,shape2,wcs2,order=0,mode='wrap')
-        omap3 = enmap.project(imap,shape3,wcs3,order=0,mode='wrap')
+        omap2 = enmap.project(imap,shape2,wcs2,order=0,border='wrap')
+        omap3 = enmap.project(imap,shape3,wcs3,order=0,border='wrap')
         assert np.all(np.isclose(omap2,1))
         assert np.all(np.isclose(omap3,1))
 
@@ -1068,7 +1068,7 @@ class PixelTests(unittest.TestCase):
             assert np.all(np.isclose(diff,0,atol=1e-3))
 
     def test_tilemap(self):
-        shape, wcs = enmap.fullsky_geometry(30*utils.degree)
+        shape, wcs = enmap.fullsky_geometry(30*utils.degree, variant="CC")
         assert shape == (7,12)
         geo  = tilemap.geometry((3,)+shape, wcs, tile_shape=(2,2))
         assert len(geo.active) == 0


### PR DESCRIPTION
There is some chance of breakage with this update. It changes the mode keyword of utils.interpol and other functions that use it, such as enmap.at, enmap.project, etc. `mode` used to control the boundary conditions, but that's now called `border`. `mode` now controls the interpolation type, e.g. if it's spline-based. This was done to start adding non-uniform fft interpolation, which is partially implemented here, but still waiting for ducc to support incremental nuffts.

There is also a small change in the behavior of enmap.submap, which can cause 1-pixel shift in the size of the maps cut out with this operation due to differences in pixel rounding.

This update also contains the start of a new way to construct geometries that will make it easier to create patches with Fejer1 pixelization. This part isn't quite done yet though, but doesn't impact the existing geometry functions.