### PR TITLE
Incremental nufft

### DIFF
--- a/pixell/bench.py
+++ b/pixell/bench.py
@@ -1,0 +1,85 @@
+import time as _time
+from contextlib import contextmanager
+from . import bunch
+
+"""bench: Simple timing of python code blocks.
+
+Example usage:
+
+	1. Manual printing
+
+	from pixell import bench
+	for i in range(nfile):
+		with bench.mark("all"):
+			with bench.mark("read"):
+				a = np.loadtxt(afiles[i])
+				b = np.loadtxt(bfiles[i])
+			with bench.mark("sum"):
+				a += b
+			with bench.mark("write"):
+				np.savetxt(ofiles[i], a)
+		print("Processed case %d in %7.4f s. read %7.4f sum %7.4f write %7.4f" % (i, bench.t.all, bench.t.read, bench.t.sum, bench.t.write))
+	print("Total %7.4f s. read %7.4f sum %7.4f write %7.4f" % (i, bench.t_tot.all, bench.t_tot.read, bench.t_tot.sum, bench.t_tot.write))
+
+	2. Quick-and-dirty printing
+
+	from pixell import bench
+	for i in range(nfile):
+		with bench.show("read"):
+			a = np.loadtxt(afiles[i])
+			b = np.loadtxt(bfiles[i])
+		with bench.show("sum"):
+			a += b
+		with bench.show("write"):
+			np.savetxt(ofiles[i], a)
+
+	bench.show is equivalent to bench.mark, just with an extra print.
+	This means that bench.show updates .ttot and .n just like bench.mark
+	does.
+
+The examples above collect statistics globally. You can create local
+benchmark objects with bench.Bench(). Example:
+
+	from pixell import bench
+	mybench = bench.Bench()
+	with mybench.mark("example"):
+		do_something()
+
+The overhead of bench.mark is around 3 µs.
+"""
+
+# Just wall times for now, but could be extended to measure
+# cpu time or leaked memory
+class Bench:
+	def __init__(self):
+		self.t_tot  = bunch.Bunch()
+		self.t      = bunch.Bunch()
+		self.n      = bunch.Bunch()
+	@contextmanager
+	def mark(self, name):
+		if name not in self.n:
+			self.t_tot[name] = 0
+			self.n[name]    = 0
+		t1 = _time.time()
+		try:
+			yield
+		finally:
+			t2 = _time.time()
+			self.n[name] += 1
+			self.t    [name] = t2-t1
+			self.t_tot[name] += t2-t1
+	@contextmanager
+	def show(self, name):
+		try:
+			with self.mark(name):
+				yield
+		finally:
+			print("%7.4f s (last) %7.4f s (mean) %4d (n) %s" % (self.t[name], self.t_tot[name]/self.n[name], self.n[name], name))
+
+# Global interface
+_default = Bench()
+mark  = _default.mark
+show  = _default.show
+t_tot = _default.t_tot
+t     = _default.t
+n     = _default.n

--- a/pixell/curvedsky.py
+++ b/pixell/curvedsky.py
@@ -425,6 +425,10 @@ class alm_info:
 		if nalm is not None:
 			assert self.nelem == nalm, "lmax must be explicitly specified when lmax != mmax"
 		self.mstart= mstart.astype(np.uint64, copy=False)
+	@property
+	def nl(self): return self.lmax+1
+	@property
+	def nm(self): return self.mmax+1
 	def lm2ind(self, l, m):
 		return (self.mstart[m].astype(int, copy=False)+l*self.stride).astype(int, copy=False)
 	def get_map(self):

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -77,7 +77,7 @@ class ndmap(np.ndarray):
 	def pixmap(self): return pixmap(self.shape, self.wcs)
 	def laxes(self, oversample=1, method="auto"): return laxes(self.shape, self.wcs, oversample=oversample, method=method)
 	def lmap(self, oversample=1): return lmap(self.shape, self.wcs, oversample=oversample)
-	def lform(self): return lform(self)
+	def lform(self, method="auto"): return lform(self, method=method)
 	def modlmap(self, oversample=1, min=0): return modlmap(self.shape, self.wcs, oversample=oversample, min=min)
 	def modrmap(self, ref="center", safe=True, corner=False): return modrmap(self.shape, self.wcs, ref=ref, safe=safe, corner=corner)
 	def lbin(self, bsize=None, brel=1.0, return_nhit=False, return_bins=False, lop=None): return lbin(self, bsize=bsize, brel=brel, return_nhit=return_nhit, return_bins=return_bins, lop=lop)
@@ -2310,7 +2310,7 @@ def apod_mask(mask, width=1*utils.degree, edge=True, profile=apod_profile_cos):
 	r = mask.distance_transform(rmax=width)
 	return profile(r/width)
 
-def lform(map):
+def lform(map, method="auto"):
 	"""Given an enmap, return a new enmap that has been fftshifted (unless shift=False),
 	and which has had the wcs replaced by one describing fourier space. This is mostly
 	useful for plotting or writing 2d power spectra.
@@ -2319,12 +2319,12 @@ def lform(map):
 	are assumed to need conversion between degrees and radians, sky2pix etc. get confused
 	when applied to lform-maps."""
 	omap = fftshift(map)
-	omap.wcs = lwcs(map.shape, map.wcs)
+	omap.wcs = lwcs(map.shape, map.wcs, method=method)
 	return omap
 
-def lwcs(shape, wcs):
+def lwcs(shape, wcs, method="auto"):
 	"""Build world coordinate system for l-space"""
-	lres   = 2*np.pi/extent(shape, wcs, signed=True)
+	lres   = 2*np.pi/extent(shape, wcs, signed=True, method=method)
 	ny, nx = shape[-2:]
 	owcs   = wcsutils.explicit(crpix=[nx//2+1,ny//2+1], crval=[0,0], cdelt=lres[::-1])
 	return owcs

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -2235,7 +2235,7 @@ def shrink_mask(mask, r):
 	"""Shrink the True part of boolean mask "mask" by a distance of r radians"""
 	return mask.distance_transform(rmax=r) >= r
 
-def pad(emap, pix, return_slice=False, wrap=False):
+def pad(emap, pix, return_slice=False, wrap=False, value=0):
 	"""Pad enmap "emap", creating a larger map with zeros filled in on the sides.
 	How much to pad is controlled via pix, which har format [{from,to},{y,x}],
 	[{y,x}] or just a single number to apply on all sides. E.g. pix=5 would pad
@@ -2250,7 +2250,7 @@ def pad(emap, pix, return_slice=False, wrap=False):
 	w = emap.wcs.deepcopy()
 	w.wcs.crpix += pix[0,::-1]
 	# Construct a slice between the new and old map
-	res = zeros(emap.shape[:-2]+tuple([s+sum(p) for s,p in zip(emap.shape[-2:],pix.T)]),wcs=w, dtype=emap.dtype)
+	res = full(emap.shape[:-2]+tuple([s+sum(p) for s,p in zip(emap.shape[-2:],pix.T)]),wcs=w, val=value, dtype=emap.dtype)
 	mslice = (Ellipsis,slice(pix[0,0],res.shape[-2]-pix[1,0]),slice(pix[0,1],res.shape[-1]-pix[1,1]))
 	res[mslice] = emap
 	if wrap:

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -546,48 +546,6 @@ def contains(shape, wcs, pos, unit="coord"):
 	else:               pix = pos
 	return np.all((pix>=0)&(pix.T<shape[-2:]).T,0)
 
-#def project(map, shape, wcs, mode="spline", order=3, border="constant",
-#		cval=0.0, force=False, safe=True, bsize=1000, ip=None):
-#	"""Project the map into a new map given by the specified
-#	shape and wcs, interpolating as necessary.
-#	This uses local interpolation, and will lose information
-#	when downgrading compared to averaging down."""
-#	# Need to think about how to handle non-spline interpolation here.
-#	# 1. Build interpolator for whole map, then evaluate for whole map.
-#	#    Large memory overhead (~14x map size for fourier-interpolation)
-#	# 2. Build interpolator for whole map, then evaluate in blocks.
-#	#    Large memory overhead (~10x map size for fourier-interpolation)
-#	# 3. Build interpolation in blocks, then evaluate in blocks.
-#	#    Problems with boundary conditions. Fourier-interpolation assumes
-#	#    periodic boundaries, but can probably get away with some padding
-#	#    and apodization.
-#
-#	# In the simplest case we just build an interpolator and evaluate
-#	# all the positions at once. But this is memory-intensive.
-#	#
-#
-#
-#
-#	# Skip expensive operation if map is compatible
-#	if not force:
-#		if wcsutils.equal(map.wcs, wcs) and tuple(shape[-2:]) == tuple(shape[-2:]):
-#			return map.copy()
-#		elif wcsutils.is_compatible(map.wcs, wcs) and border == "constant":
-#			return extract(map, shape, wcs, cval=cval)
-#	omap = zeros(map.shape[:-2]+shape[-2:], wcs, map.dtype)
-#	# Save memory by looping over rows. This won't work for non-"prefiltered" interpolators
-#	if ip and not ip.prefiltered: bsize=100000000
-#	for i1 in range(0, shape[-2], bsize):
-#		i2     = min(i1+bsize, shape[-2])
-#		somap  = omap[...,i1:i2,:]
-#		pix    = map.sky2pix(somap.posmap(), safe=safe)
-#		y1     = max(np.min(pix[0]).astype(int)-3,0)
-#		y2     = min(np.max(pix[0]).astype(int)+3,map.shape[-2])
-#		if y2-y1 <= 0: continue
-#		pix[0] -= y1
-#		somap[:] = utils.interpol(map[...,y1:y2,:], pix, mode=mode, order=order, border=border, cval=cval, ip=ip)
-#	return omap
-
 def project(map, shape, wcs, mode="spline", order=3, border="constant",
 		cval=0.0, force=False, safe=True, bsize=1000, context=50, ip=None):
 	"""Project map to a new geometry.

--- a/pixell/reproject.py
+++ b/pixell/reproject.py
@@ -92,7 +92,7 @@ def thumbnails(imap, coords, r=5*utils.arcmin, res=None, proj=None, apod=2*utils
 		# I apologize for the syntax. There should be a better way of doing this
 		ipos = coordinates.transform("cel", ["cel",[[0,0,coords[si,1],coords[si,0]],False]], opos[::-1], pol=pol)
 		ipos, rest = ipos[1::-1], ipos[2:]
-		omaps[si] = ithumb.at(ipos, order=order)
+		omaps[si] = ithumb.at(ipos, mode="spline", order=order)
 		# Apply the polarization rotation. The sign is flipped because we computed the
 		# rotation from the output to the input
 		if pol: omaps[si] = enmap.rotate_pol(omaps[si], -rest[0])
@@ -232,7 +232,7 @@ def map2healpix(imap, nside=None, lmax=None, out=None, rot=None, spin=[0,2], met
 				# Not sure why the [::-1] is necessary here. Maybe psi,theta,phi vs. phi,theta,psi?
 				pos = coordinates.transform_euler(inv_euler(rot2euler(rot))[::-1], pos, pol=pol)
 			# The actual interpolation happens here
-			vals  = imap_pre.at(pos[1::-1], order=order, prefilter=False, mode=boundary)
+			vals  = imap_pre.at(pos[1::-1], order=order, prefilter=False, mode="spline", border=boundary)
 			if rot is not None and imap.ndim > 2:
 				# Update the polarization to account for the new coordinate system
 				for s, c1, c2 in enmap.spin_helper(spin, imap.shape[-3]):

--- a/pixell/utils.py
+++ b/pixell/utils.py
@@ -3467,6 +3467,11 @@ def replace(istr, ipat, repl):
 	if ostr == istr: raise KeyError("Pattern not found")
 	return ostr
 
+def regreplace(istr, ipat, repl, count=0, flags=0):
+	ostr, n = re.subn(ipat, repl, istr, count=count, flags=flags)
+	if n == 0: raise KeyError("Pattern not found")
+	return ostr
+
 # I used to do stuff like a[~np.isfinite(a)] = 0, but this should be
 # lower overhad and faster
 def remove_nan(a):


### PR DESCRIPTION
Mostly adds incremental_nufft, which lets nufft be used effectively in interpolator objects, where you use some resources to build the interpolator, but can then query it efficiently afterwards. Useful when you don't know how many points you will apply it to ahead of time, or if you need low-latency interpolation.

This also adds fourier interpolation as an option to some functions that use interpolation. This involved a breaking change in the interface. The argument `mode` → `border`, and `mode` now controls whether spline or fourier interpolation is done. I don't think many people have used this argument yet, but I'm still worried that it could break things, so please test your codes!