### PR TITLE
Pull from development repo. Potentially breaking change in interpolation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-test clean-pyc clean-build docs help develop
+.PHONY: clean clean-test clean-pyc clean-build docs help develop build inline
 .DEFAULT_GOAL := develop
 
 define BROWSER_PYSCRIPT

--- a/pixell/cgrid.py
+++ b/pixell/cgrid.py
@@ -63,7 +63,7 @@ def fix_wcs(wcs):
 	if partial_sky: return wcs
 	else: return wcsutils.nobcheck(wcs)
 
-def calc_gridinfo(shape, wcs, steps=[2,2], nstep=[200,200], zenith=False, unit=1):
+def calc_gridinfo(shape, wcs, steps=[2,2], nstep=[200,200], zenith=False, unit=1, positive_ra=False):
 	"""Return an array of line segments representing a coordinate grid
 	for the given shape and wcs. the steps argument describes the
 	number of points to use along each meridian.
@@ -96,7 +96,7 @@ def calc_gridinfo(shape, wcs, steps=[2,2], nstep=[200,200], zenith=False, unit=1
 	for phi in start[1] + np.arange(nline[1])*steps[1]:
 		# Loop over theta
 		pixs = np.array(fix_wcs(wcs).wcs_world2pix(phi, np.linspace(box[0,0],box[1,0],nstep[0],endpoint=True), 0)).T
-		if not wcsutils.is_plain(wcs): phi = utils.rewind(phi, 0, 360)
+		if not wcsutils.is_plain(wcs) and not positive_ra: phi = utils.rewind(phi, 0, 360)
 		gridinfo.lon.append((phi/unit,prune_bad_segs(calc_line_segs(pixs),shape)))
 	# Draw lines of latitude
 	for theta in start[0] + np.arange(nline[0])*steps[0]:

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -99,7 +99,7 @@ class ndmap(np.ndarray):
 	@property
 	def geometry(self): return self.shape, self.wcs
 	def resample(self, oshape, off=(0,0), method="fft", border="wrap", corner=True, order=3): return resample(self, oshape, off=off, method=method, border=border, corner=corner, order=order)
-	def project(self, shape, wcs, mode="spline", order=3, border="constant", cval=0, safe=True): return project(self, shape, wcs, order, mode=mode, border=border, cval=cval, safe=safe)
+	def project(self, shape, wcs, mode="spline", order=3, border="constant", cval=0, safe=True): return project(self, shape, wcs, mode=mode, order=order, border=border, cval=cval, safe=safe)
 	def extract(self, shape, wcs, omap=None, wrap="auto", op=lambda a,b:b, cval=0, iwcs=None, reverse=False): return extract(self, shape, wcs, omap=omap, wrap=wrap, op=op, cval=cval, iwcs=iwcs, reverse=reverse)
 	def extract_pixbox(self, pixbox, omap=None, wrap="auto", op=lambda a,b:b, cval=0, iwcs=None, reverse=False): return extract_pixbox(self, pixbox, omap=omap, wrap=wrap, op=op, cval=cval, iwcs=iwcs, reverse=reverse)
 	def insert(self, imap, wrap="auto", op=lambda a,b:b, cval=0, iwcs=None): return insert(self, imap, wrap=wrap, op=op, cval=cval, iwcs=iwcs)

--- a/pixell/enplot.py
+++ b/pixell/enplot.py
@@ -298,6 +298,7 @@ def define_arg_parser(nodefault=False):
 	add_argument("-S", "--symmetric", action="store_true", help="Treat the non-pixel axes as being asymmetric matrix, and only plot a non-redundant triangle of this matrix.")
 	add_argument("-z", "--zenith",    action="store_true", help="Plot the zenith angle instead of the declination.")
 	add_argument("-F", "--fix-wcs",   action="store_true", help="Fix the wcs for maps in cylindrical projections where the reference point was placed too far away from the map center.")
+	add_argument(      "--pos-ra",    action="store_true", help="RA goes from 0 to 360 instead of -180 to 180")
 
 	# Define the argument parser
 	parser   = argparse.ArgumentParser()
@@ -686,7 +687,7 @@ def calc_gridinfo(shape, wcs, args):
 	try:               unit = float(args.tick_unit)
 	except TypeError:  unit = 1.0
 	except ValueError: unit = args.tick_unit
-	return cgrid.calc_gridinfo(shape, wcs, steps=ticks, nstep=args.nstep, zenith=args.zenith, unit=unit)
+	return cgrid.calc_gridinfo(shape, wcs, steps=ticks, nstep=args.nstep, zenith=args.zenith, unit=unit, positive_ra=args.pos_ra)
 
 def draw_grid(ginfo, args):
 	"""Return a grid based on gridinfo. args.grid_color controls the color

--- a/pixell/reproject.py
+++ b/pixell/reproject.py
@@ -222,7 +222,7 @@ def map2healpix(imap, nside=None, lmax=None, out=None, rot=None, spin=[0,2], met
 		# splines, but linear and nearest neighbor may be useful. Coordinate rotation may
 		# be slow.
 		import healpy
-		imap_pre = utils.interpol_prefilter(imap, npre=-2, order=order, mode=boundary)
+		ip = utils.interpolator(imap, npre=-2, order=order, mode="spline", border=boundary)
 		# Figure out if we need to compute polarization rotations
 		pol = imap.ndim > 2 and any([s != 0 for s,c1,c2 in enmap.spin_helper(spin, imap.shape[-3])])
 		# Batch to save memory
@@ -235,7 +235,7 @@ def map2healpix(imap, nside=None, lmax=None, out=None, rot=None, spin=[0,2], met
 				# Not sure why the [::-1] is necessary here. Maybe psi,theta,phi vs. phi,theta,psi?
 				pos = coordinates.transform_euler(inv_euler(rot2euler(rot))[::-1], pos, pol=pol)
 			# The actual interpolation happens here
-			vals  = imap_pre.at(pos[1::-1], order=order, prefilter=False, mode="spline", border=boundary)
+			vals  = imap.at(pos[1::-1], order=order, border=boundary, ip=ip)
 			if rot is not None and imap.ndim > 2:
 				# Update the polarization to account for the new coordinate system
 				for s, c1, c2 in enmap.spin_helper(spin, imap.shape[-3]):

--- a/pixell/utils.py
+++ b/pixell/utils.py
@@ -539,8 +539,8 @@ def interpol(arr, inds, out=None, mode="spline", border="nearest",
 	Valid values are:
 	* "nearest": Indices outside the array use the value from the nearest
 	  point on the edge.
-	* "cyclic": Periodic boundary conditions
-	* "mirrored": Mirrored boundary conditions
+	* "wrap": Periodic boundary conditions
+	* "mirror": Mirrored boundary conditions
 	* "constant": Use a constant value, given by the cval argument
 
 	Epsilon controls the target relative accuracy of the interpolation.

--- a/tests/test_pixell.py
+++ b/tests/test_pixell.py
@@ -5,7 +5,6 @@ import unittest
 from pixell import enmap
 from pixell import curvedsky
 from pixell import lensing
-from pixell import interpol
 from pixell import array_ops
 from pixell import enplot
 from pixell import powspec
@@ -19,7 +18,7 @@ from pixell import tilemap
 from pixell import utils
 import numpy as np
 import pickle
-import os,sys
+import os,sys,time
 
 import matplotlib
 matplotlib.use('Agg')
@@ -1146,3 +1145,100 @@ class PixelTests(unittest.TestCase):
         assert m1c.geometry.nactive == 2
         assert np.allclose(m1c, 1)
 
+    def test_interpol_1d(self):
+        dtype = np.float64
+        n     = 10
+        data  = np.sin(2*np.pi*3*np.arange(n)/n)
+        inds  = np.array([0.0,0.1,0.51,0.9,1.0])
+        # Nearest neighbor interpolation
+        vals  = utils.interpol(data, inds[None], mode="spline", order=0)
+        assert np.allclose(vals, data[utils.nint(inds)])
+        # Linear interpolation. This check assumes that inds is [0:1]!
+        vals  = utils.interpol(data, inds[None], mode="spline", order=1)
+        assert np.allclose(vals, data[0]*(1-inds)+data[1]*inds)
+        # Cubic spline interpolation. No simple formula here, so hardcode
+        vals  = utils.interpol(data, inds[None], mode="spline", order=3)
+        assert np.allclose(vals, [-1.39824833112681842e-12, 1.16478779103952171e-01, 6.66141591529904153e-01, 9.62884886419913988e-01, 9.51056516295153753e-01])
+        # Nufft interpolation
+        vals  = utils.interpol(data, inds[None], mode="fourier")
+        targ  = np.sin(2*np.pi*3*inds/n)
+        assert np.allclose(vals, targ)
+
+    def test_interpol_map(self):
+        # Make a small map to interpolate. We will simply use the angular distance
+        # from the center, which avoids any non-periodicity issues
+        shape, wcs = enmap.geometry([[-1,1],[1,-1]], res=0.1, deg=True, proj="car")
+        # Make test cases where the exact answer is known. Bilinear is easy for a linear field,
+        # and NN is easy anywayre
+        dtype = np.float64
+        ypix  = np.arange(shape[-2], dtype=dtype)
+        xpix  = np.arange(shape[-1], dtype=dtype)
+        opix  = np.array([[10,10.2],[10,12.7]])
+        # NN and bilinear
+        def f(y,x): return 2*y-x
+        data  = enmap.enmap(f(ypix[:,None],xpix[None,:]),wcs)
+        vals  = data.at(opix, unit="pix", mode="spline", order=0)
+        targ  = data[tuple(utils.nint(opix))]
+        assert np.allclose(vals, targ)
+        vals  = data.at(opix, unit="pix", mode="spline", order=1)
+        targ  = f(*opix)
+        assert np.allclose(vals, targ)
+        # Bicubic is exact up to 3rd order, but only if we ignore
+        # boundary conditions. I'm not sure how to calculate the
+        # expected answer here, so just hardcode it
+        def f(y,x): return y**3+2*y**2+3*y-2*x**3-3*x**2-4*x+x*y
+        data  = enmap.enmap(f(ypix[:,None],xpix[None,:]),wcs)
+        vals  = data.at(opix, unit="pix", mode="spline", order=3)
+        targ  = np.array([-1.01000000000000000e+03, -3.20214384455599429e+03])
+        assert np.allclose(vals, targ)
+        # Fourier is simple. All fourier modes up to Nyquist are exact.
+        # Nufft adds some inaccuracy, but it's tiny
+        def f(y,x): return np.sin(2*np.pi*3*y/shape[-2])+np.cos(2*np.pi*5*x/shape[-1])
+        data  = enmap.enmap(f(ypix[:,None],xpix[None,:]),wcs)
+        vals  = data.at(opix, unit="pix", mode="fourier")
+        targ  = f(*opix)
+        assert np.allclose(vals, targ)
+
+    def test_interpol_map_Nd(self):
+        # Test that multidimensional interpolation works
+        shape, wcs = enmap.geometry([[-1,1],[1,-1]], res=0.1, deg=True, proj="car")
+        dtype = np.float64
+        ypix  = np.arange(shape[-2], dtype=dtype)
+        xpix  = np.arange(shape[-1], dtype=dtype)
+        def f(y,x): return np.sin(2*np.pi*3*y/shape[-2])+np.cos(2*np.pi*5*x/shape[-1])
+        data  = (1+np.arange(12)).reshape(3,4)[:,:,None,None]*enmap.enmap(f(ypix[:,None],xpix[None,:]),wcs)
+        opix  = np.array([[10,10.2],[10,12.7]])
+        vals  = data.at(opix, unit="pix")
+        assert vals.shape == (3,4)+opix.shape[1:]
+        targ  = vals*0
+        for I in utils.nditer(data.shape[:-2]):
+            targ[I] = data[I].at(opix, unit="pix")
+        assert np.allclose(vals, targ)
+
+    def test_interpolator(self):
+        # Test that lookups using an interpolator work, and are fast.
+        # Use a decently large array to be sure we can measure the
+        # speed difference.
+        shape = (1000,1000)
+        dtype = np.float64
+        ypix  = np.arange(shape[-2], dtype=dtype)
+        xpix  = np.arange(shape[-1], dtype=dtype)
+        opix  = np.array([[10,10.2],[10,12.7]])
+        def f(y,x): return np.sin(2*np.pi*3*y/shape[-2])+np.cos(2*np.pi*5*x/shape[-1])
+        data  = f(ypix[:,None],xpix)
+        cases = [("spline",3),("fourier",None)]
+        for ci, (mode,order) in enumerate(cases):
+            t1 = time.time()
+            vals_raw = utils.interpol(data, opix, mode=mode, order=order)
+            t2 = time.time()
+            ip = utils.interpolator(data, mode=mode, order=order)
+            t3 = time.time()
+            vals_ip  = ip(opix)
+            t4 = time.time()
+            assert np.allclose(vals_ip, vals_raw)
+            time_full  = t2-t1
+            time_eval  = t4-t3
+            assert time_eval < time_full / 100
+            # Also test that we can pass the interpolator as an argument
+            vals_ip2 = utils.interpol(data, opix, mode=mode, order=order, ip=ip)
+            assert np.allclose(vals_ip2, vals_raw)


### PR DESCRIPTION
This pull request accumulates many minor changes, but changes some of the arguments to interpolation functions in order to support non-uniform fourier interpolation. This can break code that uses these arguments, but I'm not aware of any such code beyond my own.

Summary of the interpolation changes:

* Previously `utils.interpol`, and all functions built on top of it, like `enmap.at` and `enmap.project`, only supported ndimage.map_coordinate's spline interpolation. The `mode` argument controlled the boundary condition, while the `order` argument controlled the spline order. This has been changed such that `mode` now controls the interpolation type, while the boundary condition is controlled with the `border` argument.
* `mode` now has two valid values: "spline" for spline interpolation and "fourier" for non-uniform fft interpolation. This relies on a recent version of ducc0.
* `utils.interpolator` has been added, which constructs an object that can be used to do fast interpolation on future data points. This precomputes everything that does not depend on the interpolation coordinates. There's no point in doing this if all the coordinates are already available, but it's useful to have this if one wants to gradually read off from new coordinates, e.g. for low-latency printing of the value under a mouse cursor. `utils.interpolator` takes the same arguments as `utils.interpol`, minus the coordinates., and returns either a `SplineInterpolator` or a `FourierInterpolator`. This depends on an even newer version of ducc0, but it's still available on pypi.
* `utils.interpol`, and functions that use it, can now take an interpolator as an optional argument, which makes them use that interpolator instead of building one themselves.
* `reproject.thumbnails` has a new argument `mode`. It currently defaults to "mixed", which gives the old behavior of first fourier-upscaling and then spline-interpolating. This was needed before because non-uniform ffts weren't available, but they are now. To use nufft, pass `mode="nufft"`. This should be both more accurate, faster and use less memory. It will probably be made the default at some point. The last value is "spline", which is fast but inaccurate. It can still be useful in some cases though.