### PR TITLE
Lens map curved with lenspyx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     'coveralls>=1.5',
     'pytest>=4.6',
     'ducc0>=0.36.0',
-    'numba>=0.54.0'
+    'numba>=0.54.0',
+    'lenspyx>=2.0'
 ]
 
 [project.scripts]


### PR DESCRIPTION
Adds `lens_map_curved_lenspyx` function to `pixell.lensing`. This would improve things in 2 ways:

1. I believe it would fix https://github.com/simonsobs/pixell/issues/283
2. I think it would be better to delegate the curved-sky lensing operation to `lenspyx`, since that is "the" optimized/specialized CMB lensing library, rather than try to maintain our own method in parallel.

One thing to note is that this new function has two (minor) limitations that are not fundamental:

1. It relies on a helper function to perform surgery on the `lenspyx` output maps, since they don't natively know about the desired geometry. This output function should work in most cases but would fail if https://github.com/simonsobs/pixell/issues/202 is not fixed for edge cases
2. It doesn't handle all possible spin permutations, but these could be added and caught. It's just that for now, the default `[0, 2]` I think will cover 99% of use-cases. 

The lensing output maps aren't identical (see below for T, E, B difference maps for a standard cosmology) but their power spectra are very similar (`lmax=2700` for `phi_alm` and `cmb_alm`, 4 arcmin pixels on full-sky `fejer1` geometry), see below (note `np.max(np.abs(lenspyx - pixell))` is ~`(20, 14, 12)` uK):

![t_diff](https://github.com/user-attachments/assets/5b6a9ca5-77d0-4ac0-8c4a-cdc17931aac9)
![q_diff](https://github.com/user-attachments/assets/ea1a20d1-2ff6-472b-9b79-39c644f8fe9e)
![u_diff](https://github.com/user-attachments/assets/2b5d92b9-894a-40f6-b76b-9abcdc68bfbd)
![l](https://github.com/user-attachments/assets/cfc30c17-d0a2-4452-9195-8908b57af2dd)
![p](https://github.com/user-attachments/assets/dd7fad88-e33d-4479-bbe8-be96ead52cbc)


