### PR TITLE
separating fake communicator from mpifile

### DIFF
--- a/pixell/fake_communicator.py
+++ b/pixell/fake_communicator.py
@@ -1,0 +1,36 @@
+import numpy as np
+import copy
+
+
+def _unbuf(bufspec):
+    return bufspec[0] if isinstance(bufspec, tuple) else np.asarray(bufspec)
+
+
+class FakeCommunicator:
+    def __init__(self):
+        self.size = 1
+        self.rank = 0
+
+    def Allreduce(self, sendbuf, recvbuf, op=lambda a, b: a + b):
+        _unbuf(recvbuf)[()] = _unbuf(sendbuf)
+
+    def Allgather(self, sendbuf, recvbuf):
+        _unbuf(recvbuf)[0] = _unbuf(sendbuf)
+
+    def Allgatherv(self, sendbuf, recvbuf):
+        _unbuf(recvbuf)[()] = _unbuf(sendbuf)
+
+    def Alltoallv(self, sendbuf, recvbuf):
+        _unbuf(recvbuf)[()] = _unbuf(sendbuf)
+
+    def Barrier(self):
+        pass
+
+    def allreduce(self, sendobj, op=lambda a, b: a + b):
+        return copy.deepcopy(sendobj)
+
+    def allgather(self, sendobj, op=lambda a, b: a + b):
+        return [copy.deepcopy(sendobj)]
+
+    def allgatherv(self, sendobj, op=lambda a, b: a + b):
+        return [copy.deepcopy(sendobj)]

--- a/pixell/meson.build
+++ b/pixell/meson.build
@@ -9,6 +9,7 @@ python_sources = [
     'colors.py',
     'coordinates.py',
     'curvedsky.py',
+    'fake_communicator.py',
     'enmap.py',
     'enplot.py',
     'fft.py',

--- a/pixell/mpi.py
+++ b/pixell/mpi.py
@@ -2,28 +2,7 @@
 from __future__ import print_function
 import sys, os, traceback, copy, numpy as np
 
-def _unbuf(bufspec):
-    return bufspec[0] if isinstance(bufspec, tuple) else np.asarray(bufspec)
-
-class FakeCommunicator:
-    def __init__(self):
-        self.size = 1
-        self.rank = 0
-    def Allreduce(self, sendbuf, recvbuf, op=lambda a,b:a+b):
-        _unbuf(recvbuf)[()] = _unbuf(sendbuf)
-    def Allgather(self, sendbuf, recvbuf):
-        _unbuf(recvbuf)[0] = _unbuf(sendbuf)
-    def Allgatherv(self, sendbuf, redvbuf):
-        _unbuf(recvbuf)[()] = _unbuf(sendbuf)
-    def Alltoallv(self, sendbuf, recvbuf):
-        _unbuf(recvbuf)[()] = _unbuf(sendbuf)
-    def Barrier(self): pass
-    def allreduce(self, sendobj, op=lambda a,b:a+b):
-        return copy.deepcopy(sendobj)
-    def allgather(self, sendobj, op=lambda a,b:a+b):
-        return [copy.deepcopy(sendobj)]
-    def allgatherv(self, sendobj, op=lambda a,b:a+b):
-        return [copy.deepcopy(sendobj)]
+from .fake_communicator import FakeCommunicator
 
 FAKE_WORLD = FakeCommunicator()
 COMM_WORLD = FAKE_WORLD


### PR DESCRIPTION
Isolating the FakeCommunicator class. It is a very useful class, but the star import from mpi4py affects mpi4py's behavior I do not need a whole MPI world or the world does not exist (running other types of parallelization).

This does not change the functionality of the `mpi.py` as the FakeCommunicator class is imported by it. It just makes sure that the FakeCommunicator can be imported in isolation.

PR simonsobs/sotodlib#1096 depends on this
