### PR TITLE
fixed queb_rotmat, handles all cdelt cases, made tests more general

### DIFF
--- a/pixell/multimap.py
+++ b/pixell/multimap.py
@@ -240,11 +240,8 @@ def harm2map_adjoint(mmap, nthread=0, normalize=True, iau=False, spin=[0,2]):
 	return map2harm(mmap, nthread=nthread, normalize=normalize, iau=iau, spin=spin, adjoint_harm2map=True)
 
 def queb_rotmat(lmap, inverse=False, iau=False, spin=2):
-	sgn = 1 if iau else -1
-	a    = sgn*spin*np.arctan2(-lmap[1], lmap[0])
-	c, s = np.cos(a), np.sin(a)
-	if inverse: s = -s
-	return samegeos(np.array([[c,-s],[s,c]]),lmap)
+	out = enmap.queb_rotmat(lmap, inverse=inverse, iau=iau, spin=spin)
+	return samegeos(out,lmap)
 
 def rotate_pol(mmap, angle, comps=[-2,-1]):
 	c, s = np.cos(2*angle), np.sin(2*angle)

--- a/tests/test_pixell.py
+++ b/tests/test_pixell.py
@@ -461,6 +461,37 @@ class PixelTests(unittest.TestCase):
         np.testing.assert_allclose(out, out_exp, atol=1e-12)
         self.assertTrue(out.flags['C_CONTIGUOUS'])
 
+    def test_queb_rotmat(self):
+        # Tests that the rotmat respects fft symmetry constraints
+        # for real maps -- ie, map2harm, harm2map produces 
+        # sensible round-trips
+        ishapes = [(50, 50), (50, 51), (51, 50), (51, 51)]
+        dtypes = [np.complex64, np.complex128]
+        comps = [1, 2] # this is the comp we will set to non-zero
+
+        for ishape, dtype, comp in itertools.product(ishapes, dtypes, comps):
+            shape, wcs = enmap.geometry(pos=(0, 0), shape=ishape, res=0.01)
+
+            # define some easy test input to evaluate for mixing
+            input_complex_hmap = enmap.zeros((3, *shape), wcs, dtype=dtype)
+            input_complex_hmap[comp] += 1. + 1.j
+            output_complex_hmap = enmap.zeros((3, *shape), wcs, dtype=dtype)
+            output_complex_hmap[comp] += 1.
+
+            # do a round-trip and check that we get what we expect.
+            # the queb operations mix E and B and could lead to artifacts if
+            # we're not careful
+            if input_complex_hmap.real.dtype.itemsize == 8:
+                atol = 1e-10
+            elif input_complex_hmap.real.dtype.itemsize == 4:
+                atol = 1e-5
+            test_output_complex_hmap = enmap.map2harm(
+                enmap.harm2map(input_complex_hmap)
+                )
+            assert np.allclose(
+                test_output_complex_hmap, output_complex_hmap, rtol=0, atol=atol
+                ), f'{ishape=}, {dtype=}, {comp=}'
+
     def test_extract(self):
         # Tests that extraction is sensible
         shape,wcs = enmap.geometry(pos=(0,0),shape=(500,500),res=0.01)
@@ -516,63 +547,71 @@ class PixelTests(unittest.TestCase):
 
     def test_b_sign(self):
         """
-        We generate a random IQU map with geometry such that cdelt[0]<0
+        We generate a random IQU map with geometry such that cdelt[0]<0 and
+        cdelt[1]>0.
         We transform this to TEB with map2harm and map2alm followed by 
         scalar harm2map and alm2map and use these as reference T,E,B maps.
-        We flip the original map along the RA direction.
+        We flip the original map along the RA direction, Dec direction, or both.
         We transform this to TEB with map2harm and map2alm followed by 
         scalar harm2map and alm2map and use these as comparison T,E,B maps.
         We compare these maps.
         """
-        ells,cltt,clee,clbb,clte = np.loadtxt(DATA_PREFIX+"cosmo2017_10K_acc3_lensedCls.dat",unpack=True)
-        ps_cmb = np.zeros((3,3,ells.size))
+        cltt,clee,clbb,clte = powspec.read_spectrum(DATA_PREFIX+"cosmo2017_10K_acc3_lensedCls.dat",expand=None)
+
+        ps_cmb = np.zeros((3,3,cltt.size))
         ps_cmb[0,0] = cltt
         ps_cmb[1,1] = clee
         ps_cmb[2,2] = clbb
         ps_cmb[1,0] = clte
         ps_cmb[0,1] = clte
-        np.random.seed(100)
-
-        # Curved-sky is fine
-        lmax = 1000
-        alm = curvedsky.rand_alm_healpy(ps_cmb,lmax=lmax)
-        shape,iwcs = enmap.fullsky_geometry(res=np.deg2rad(10./60.))
-        wcs = enmap.empty(shape,iwcs)[...,::-1].wcs
-        shape = (3,) + shape
-        imap = curvedsky.alm2map(alm,enmap.empty(shape,wcs))
-        oalm = curvedsky.map2alm(imap.copy(),lmax=lmax)
-        rmap = curvedsky.alm2map(oalm,enmap.empty(shape,wcs),spin=0)
-
-        imap2 = imap.copy()[...,::-1]
-        oalm = curvedsky.map2alm(imap2.copy(),lmax=lmax)
-        rmap2 = curvedsky.alm2map(oalm,enmap.empty(shape,wcs),spin=0)
-
-        assert np.all(np.isclose(rmap[0],rmap2[0]))
-        assert np.all(np.isclose(rmap[1],rmap2[1]))
-        assert np.all(np.isclose(rmap[2],rmap2[2]))
-        
-
-        # Flat-sky
-        px = 2.0
-        N = 300
-        shape,iwcs = enmap.geometry(pos=(0,0),res=np.deg2rad(px/60.),shape=(300,300))
-        shape = (3,) + shape
-        a = enmap.zeros(shape,iwcs)
-        a = a[...,::-1]
-        wcs = a.wcs
-
         seed = 100
-        imap = enmap.rand_map(shape,wcs,ps_cmb,seed=seed)
-        kmap = enmap.map2harm(imap.copy())
-        rmap = enmap.harm2map(kmap,spin=0) # reference map
 
-        imap = imap[...,::-1]
-        kmap = enmap.map2harm(imap.copy())
-        rmap2 = enmap.harm2map(kmap,spin=0)[...,::-1] # comparison map
-        
-        assert np.all(np.isclose(rmap[0],rmap2[0]))
-        assert np.all(np.isclose(rmap[1],rmap2[1],atol=1e0))
-        assert np.all(np.isclose(rmap[2],rmap2[2],atol=1e0))
+        # test all possible cdelt flips and shapes
+        sels = (np.s_[...], np.s_[...,::-1], np.s_[...,::-1,:], np.s_[...,::-1,::-1])
+
+        Ny, Nx = 1080, 2160 
+        shapes = ((Ny, Nx), (Ny-1, Nx), (Ny, Nx-1), (Ny-1, Nx-1))
+        for ishape, sel in itertools.product(shapes, sels):
+            # Curved-sky
+            lmax = 1000
+            alm = curvedsky.rand_alm_healpy(ps_cmb,lmax=lmax,seed=seed)
+            shape,iwcs = enmap.fullsky_geometry(shape=ishape)
+            wcs = enmap.empty(shape,iwcs)[sel].wcs
+            shape = (3,) + shape
+            imap = curvedsky.alm2map(alm,enmap.empty(shape,wcs))
+            oalm = curvedsky.map2alm(imap.copy(),lmax=lmax)
+            rmap = curvedsky.alm2map(oalm,enmap.empty(shape,wcs),spin=0) # reference map
+
+            imap2 = imap.copy()[sel]
+            oalm = curvedsky.map2alm(imap2.copy(),lmax=lmax)
+            rmap2 = curvedsky.alm2map(oalm,enmap.empty(shape,wcs),spin=0) # comparison map
+
+            assert np.allclose(rmap[0],rmap2[0],atol=0,rtol=1e-7)
+            assert np.allclose(rmap[1],rmap2[1],atol=0,rtol=1e-7)
+            assert np.allclose(rmap[2],rmap2[2],atol=0,rtol=1e-7)
+            
+        Ny, Nx = 300, 300 
+        shapes = ((Ny, Nx), (Ny-1, Nx), (Ny, Nx-1), (Ny-1, Nx-1))
+        for ishape, sel in itertools.product(shapes, sels):
+            # Flat-sky
+            px = 2.0
+            shape,iwcs = enmap.geometry(pos=(0,0),res=np.deg2rad(px/60.),shape=ishape)
+            shape = (3,) + shape
+            a = enmap.zeros(shape,iwcs)
+            a = a[sel]
+            wcs = a.wcs
+
+            imap = enmap.rand_map(shape,wcs,ps_cmb,seed=seed)
+            kmap = enmap.map2harm(imap.copy())
+            rmap = enmap.harm2map(kmap,spin=0) # reference map
+
+            imap = imap[sel]
+            kmap = enmap.map2harm(imap.copy())
+            rmap2 = enmap.harm2map(kmap,spin=0)[sel] # comparison map
+            
+            assert np.allclose(rmap[0],rmap2[0],atol=0,rtol=1e-7), f'{ishape=}, {sel=}'
+            assert np.allclose(rmap[1],rmap2[1],atol=0,rtol=1e-7), f'{ishape=}, {sel=}'
+            assert np.allclose(rmap[2],rmap2[2],atol=0,rtol=1e-7), f'{ishape=}, {sel=}'
 
     def test_plain_wcs(self):
         # Test area and box for a small Cartesian geometry


### PR DESCRIPTION
This fixes https://github.com/simonsobs/pixell/issues/288

The fundamental issue is that the previous `enmap.queb_rotmat` implementation did not respect symmetries required by the DFT of a real map. This induced E<->B mixing at the Nyquist frequency, where these symmetries were being violated by the sine term of the rotmat.  This fix respects the symmetries, and also is consistent for all possible variations of the signs of `cdeltx` and `cdelty` and well as even/odd map shapes in x and y. I added a new test to catch this.

Handling the possibilities of non-standard `cdelt` was important to pass `test_b_sign` in the existing tests -- basically, in the case that a user flips their map in between performing `map2harm` and `harm2map` operations. I generalized this test for all possible variations of the signs of `cdeltx` and `cdelty` and well as even/odd map shapes in x and y