### PR TITLE
Fix lonpole in zenithal projections

### DIFF
--- a/pixell/wcsutils.py
+++ b/pixell/wcsutils.py
@@ -427,6 +427,30 @@ def mer(pos, res=None, shape=None, rowmajor=False, ref=None):
 	if streq(ref, "standard"): ref = (0,0)
 	return finalize(w, pos, res, shape, ref=ref)
 
+def arc(pos, res=None, shape=None, rowmajor=False, ref=None):
+	"""Setups up a zenithal equidistant projection.  See the build
+	function for details.
+
+	"""
+	pos, res, shape, mid = validate(pos, res, shape, rowmajor)
+	w = WCS(naxis=2)
+	w.wcs.ctype = ["RA---ARC", "DEC--ARC"]
+	w.wcs.crval = mid
+	w, ref = _apply_zenithal_ref(w, ref)
+	return finalize(w, pos, res, shape, ref=ref)
+
+def sin(pos, res=None, shape=None, rowmajor=False, ref=None):
+	"""Setups up an orthographic projection.  See the build function
+	for details.
+
+	"""
+	pos, res, shape, mid = validate(pos, res, shape, rowmajor)
+	w = WCS(naxis=2)
+	w.wcs.ctype = ["RA---SIN", "DEC--SIN"]
+	w.wcs.crval = mid
+	w, ref = _apply_zenithal_ref(w, ref)
+	return finalize(w, pos, res, shape, ref=ref)
+
 def zea(pos, res=None, shape=None, rowmajor=False, ref=None):
 	"""Setups up an oblate Lambert's azimuthal equal area system.
 	See the build function for details. Don't use this if you want
@@ -464,7 +488,7 @@ def tan(pos, res=None, shape=None, rowmajor=False, ref=None):
 	w, ref = _apply_zenithal_ref(w, ref)
 	return finalize(w, pos, res, shape, ref=ref)
 
-systems = {"car": car, "cea": cea, "mer": mer, "air": air, "zea": zea, "tan": tan, "gnom": tan, "plain": plain }
+systems = {"car": car, "cea": cea, "mer": mer, "air": air, "arc": arc, "sin": sin, "zea": zea, "tan": tan, "gnom": tan, "plain": plain }
 
 def build(pos, res=None, shape=None, rowmajor=False, system="cea", ref=None, **kwargs):
 	"""Set up the WCS system named by the "system" argument.
@@ -537,7 +561,10 @@ def _apply_zenithal_ref(w, ref):
 	"""Input is a wcs w and ref is a position (dec,ra) or a special value
 	(None, 'standard').  Returns tuple (w, ref_out).  If ref is a
 	position, it is copied into w.wcs.crval and ref_out=ref.
-	Otherwise, w is unmodified and ref_out=w.wcs.crval."""
+	Otherwise, w is unmodified and ref_out=w.wcs.crval.  Also sets lonpole,
+	if not already set, to 180, which is sensible default."""
+	if np.isnan(w.wcs.lonpole):
+		w.wcs.lonpole = 180.
 	if isinstance(ref, str) and ref == 'standard':
 		ref = None
 	if ref is None:

--- a/pixell/wcsutils.py
+++ b/pixell/wcsutils.py
@@ -73,7 +73,7 @@ def pixelization(pwcs, shape=None, res=None, variant=None):
 	# some have infinite size. May just have to handle the cases one by
 	# one instead of trying to be general
 	system   = get_proj(pwcs)
-	extent   = default_extent(system)
+	extent, lonpole   = default_extent(system)
 	variant  = variant or default_variant(system)
 	offs     = parse_variant(variant)
 	periodic = is_periodic(system)
@@ -93,6 +93,8 @@ def pixelization(pwcs, shape=None, res=None, variant=None):
 	owcs  = pwcs.deepcopy()
 	owcs.wcs.cdelt = [(ra2-ra1)/(nx-1), (dec2-dec1)/(ny-1)]
 	owcs.wcs.crpix = [1+(pwcs.wcs.crval[0]-ra1)/owcs.wcs.cdelt[0],1+(pwcs.wcs.crval[1]-dec1)/owcs.wcs.cdelt[1]]
+	if lonpole is not None:
+		owcs.wcs.lonpole = lonpole
 	return (ny,nx), owcs
 
 def explicit(naxis=2, **args):
@@ -216,23 +218,26 @@ def default_crval(system):
 	else: return [0,0]
 
 def default_extent(system):
-	"""Return the horizontal and vertical extent of the full sky in degrees.
-	For some systems the full sky is not representable, in which case a
-	reasonable compromise is returned"""
+	"""Return the horizontal and vertical extent of the full sky in
+	degrees, and the prefered value of lonpole (or None if it should
+	be left alone).  For some systems the full sky is not
+	representable, in which case a reasonable compromise is returned
+
+	"""
 	system = system.lower()
-	if   system in ["", "plain"]: return [1,1]
+	if   system in ["", "plain"]: return [1,1], None
 	# Cylindrical
-	if   system == "car": return [360,180]
-	elif system == "cea": return [360,360/np.pi]
-	elif system == "mer": return [360,360] # traditional dec range gives square map
+	if   system == "car": return [360,180], None
+	elif system == "cea": return [360,360/np.pi], None
+	elif system == "mer": return [360,360], None # traditional dec range gives square map
 	# Zenithal
-	elif system == "arc": return [360,360]
-	elif system == "zea": return [720/np.pi,720/np.pi]
-	elif system == "sin": return [360/np.pi,360/np.pi] # only orthographic supported
-	elif system == "tan": return [360,360] # goes down to 0.158° above the horizon
+	elif system == "arc": return [360,360], 180.
+	elif system == "zea": return [720/np.pi,720/np.pi], 180.
+	elif system == "sin": return [360/np.pi,360/np.pi], 180. # only orthographic supported
+	elif system == "tan": return [360,360], 180. # goes down to 0.158° above the horizon
 	# Pseudo-cyl
-	elif system == "mol": return [720*2**0.5/np.pi,360*2**0.5/np.pi]
-	elif system == "ait": return [720*2**0.5/np.pi,360*2**0.5/np.pi]
+	elif system == "mol": return [720*2**0.5/np.pi,360*2**0.5/np.pi], None
+	elif system == "ait": return [720*2**0.5/np.pi,360*2**0.5/np.pi], None
 	else: raise ValueError("Unsupported system '%s'" % str(system))
 
 def default_variant(system):

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -73,6 +73,23 @@ class GeometryTests(unittest.TestCase):
             assert(np.all(is_centered(pix0)))
             assert(np.all(is_centered(pix1)))
 
+    def test_zenithal_lonpole(self):
+        """For zenithal projs, test that lonpole is set to 180, even
+        if the reference point is the north pole.
+
+        """
+        DELT = 0.05
+        for ep in [DELT * 2, 0]:
+            patch = Patch.centered_at(0., 90.-ep, 0., 0.)
+            for proj in ['tan', 'zea', 'arc', 'sin']:
+                shape, wcs = enmap.geometry(pos=patch.center() * DEG,
+                                              shape=(101, 101),
+                                              res=DELT*utils.degree,
+                                              proj=proj)
+                dec, ra = enmap.posmap(shape, wcs)
+                # Bottom row of the map only have RA near 0 (not 180).
+                assert np.all(abs(ra[0]) < 90*DEG)
+
     def test_full_sky(self):
         """Test that fullsky_geometry returns sensible objects.
 

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -79,16 +79,17 @@ class GeometryTests(unittest.TestCase):
 
         """
         DELT = 0.05
-        for ep in [DELT * 2, 0]:
-            patch = Patch.centered_at(0., 90.-ep, 0., 0.)
-            for proj in ['tan', 'zea', 'arc', 'sin']:
-                shape, wcs = enmap.geometry(pos=patch.center() * DEG,
+        for geometry_gen in [enmap.geometry, enmap.geometry2]:
+            for ep in [DELT * 2, 0]:
+                patch = Patch.centered_at(0., 90.-ep, 0., 0.)
+                for proj in ['tan', 'zea', 'arc', 'sin']:
+                    shape, wcs = geometry_gen(pos=patch.center() * DEG,
                                               shape=(101, 101),
                                               res=DELT*utils.degree,
                                               proj=proj)
-                dec, ra = enmap.posmap(shape, wcs)
-                # Bottom row of the map only have RA near 0 (not 180).
-                assert np.all(abs(ra[0]) < 90*DEG)
+                    dec, ra = enmap.posmap(shape, wcs)
+                    # Bottom row of the map only have RA near 0 (not 180).
+                    assert np.all(abs(ra[0]) < 90*DEG)
 
     def test_full_sky(self):
         """Test that fullsky_geometry returns sensible objects.


### PR DESCRIPTION
geometry2() would always set lonpole=0 for zenithal projs, where geometry() would almost always set lonpole=180.  This PR:
- updates geometry() so it sets lonpole=180, even if CRVAL is the north pole.
- updates geometry2() to behave the same way as geometry().
- Adds ARC and SIN projections to geometry() (these were already supported by geometry2).
- Adds test to confirm that zenithal maps are oriented as we would like, by default, with the RA=0 line intersecting the bottom of the map.