### PR TITLE
Introducing numpy2 and python3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.12", "3.11", "3.10"]
+        python: ["3.13", "3.12", "3.11", "3.10"]
 
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install Dependencies (MacOS)
         run: |

--- a/pixell/coordinates.py
+++ b/pixell/coordinates.py
@@ -371,7 +371,7 @@ def getsys_full(sys, time=None, site=default_site, bore=None):
 			r = toks[0]
 			refsys = getsys(toks[1]) if len(toks) > 1 else prevsys
 			try:
-				r = np.asfarray(r.split("_"))*utils.degree
+				r = np.asarray(r.split("_"), dtype=np.float64)*utils.degree
 				assert(r.ndim == 1 and len(r) == 2)
 				r = transform_raw(refsys, base, r[:,None], time=time, site=site, bore=bore)
 			except ValueError:

--- a/pixell/enmap.py
+++ b/pixell/enmap.py
@@ -899,7 +899,7 @@ def extent_subgrid(shape, wcs, nsub=None, safe=True, signed=False):
 	if nsub is None: nsub = 17
 	# Create a new wcs with (nsub,nsub) pixels
 	wcs = wcs.deepcopy()
-	step = (np.asfarray(shape[-2:])/nsub)[::-1]
+	step = (np.asarray(shape[-2:], dtype=np.float64)/nsub)[::-1]
 	wcs.wcs.crpix -= 0.5
 	wcs.wcs.cdelt *= step
 	wcs.wcs.crpix /= step

--- a/pixell/interpol.py
+++ b/pixell/interpol.py
@@ -55,7 +55,7 @@ def map_coordinates(idata, points, odata=None, mode="spline", order=3, border="c
 	core    = get_core(idata.dtype)
 	ndim    = points.shape[0]
 	dpre,dpost= idata.shape[:-ndim], idata.shape[-ndim:]
-	def iprod(x): return np.product(x).astype(int)
+	def iprod(x): return np.prod(x).astype(int)
 	if not trans:
 		if odata is None:
 			if not deriv:
@@ -128,8 +128,8 @@ def build(func, interpolator, box, errlim, maxsize=None, maxtime=None, return_ob
 	automatically polls func and constructs an interpolator
 	object that has the required accuracy inside the provided
 	bounding box."""
-	box     = np.asfarray(box)
-	errlim  = np.asfarray(errlim)
+	box     = np.asarray(box, dtype=np.float64)
+	errlim  = np.asarray(errlim, dtype=np.float64)
 	idim    = box.shape[1]
 	n       = [3]*idim if nstart is None else nstart
 	n       = np.array(n) # starting mesh size
@@ -147,7 +147,7 @@ def build(func, interpolator, box, errlim, maxsize=None, maxtime=None, return_ob
 	# Refine until good enough
 	while True:
 		depth += 1
-		if maxsize and np.product(n) > maxsize:
+		if maxsize and np.prod(n) > maxsize:
 			if return_status:
 				return ip if not return_obox else ip, np.array(obox), False, err
 			raise OverflowError("Maximum refinement mesh size exceeded")
@@ -265,7 +265,7 @@ def lin_derivs_forward(y, npre=0):
 	dimensions, returning an array of shape (2,)*n+(:,)*npre+(:-1,)*n. That is,
 	it is one shorter in each direction along which the derivative is taken.
 	Derivatives are computed using forward difference."""
-	y        = np.asfarray(y)
+	y        = np.asarray(y, dtype=np.float64)
 	nin      = y.ndim-npre
 	ys = np.zeros((2,)*nin+y.shape)
 	ys[(0,)*nin] = y
@@ -283,7 +283,7 @@ def grad_forward(y, npre=0):
 	"""Given an array y with npre leading dimensions and n following dimensions,
 	the gradient along the n last dimensions, returning an array of shape (n,)+y.shape.
 	Derivatives are computed using forward difference."""
-	y        = np.asfarray(y)
+	y        = np.asarray(y, dtype=np.float64)
 	nin      = y.ndim-npre
 	dy       = np.zeros((nin,)+y.shape)
 	for i in range(nin):

--- a/pixell/reproject.py
+++ b/pixell/reproject.py
@@ -380,7 +380,7 @@ def rot2euler(rot):
 		else: raise ValueError("Unrecognized system '%s'" % osys)
 		return R.as_euler("zyz")
 	else:
-		rot = np.asfarray(rot)
+		rot = np.asarray(rot, dtype=np.float64)
 		return rot
 
 def inv_euler(euler): return [-euler[2], -euler[1], -euler[0]]

--- a/pixell/tilemap.py
+++ b/pixell/tilemap.py
@@ -378,7 +378,7 @@ class TileGeometry:
 	@property
 	def nactive(self): return len(self.active)
 	@property
-	def size(self): return np.product(self.pre)*np.sum(self.npixs[self.active])
+	def size(self): return np.prod(self.pre)*np.sum(self.npixs[self.active])
 	@property
 	def tiles(self):
 		"""Allow us to get the enmap geometry of tile #i by writing
@@ -453,8 +453,8 @@ def redistribute(imap, comm, active=None, omap=None):
 	# 3. Figure out who I should send and receive each of my tiles to/from
 	omask     = oactive_all[:,imap.active] # [ntasks,iactive]
 	imask     = iactive_all[:,omap.active] # [ntasks,oactive]
-	isizes    = imap.geometry.npixs[imap.active] * np.product(imap.pre).astype(int)
-	osizes    = omap.geometry.npixs[omap.active] * np.product(omap.pre).astype(int)
+	isizes    = imap.geometry.npixs[imap.active] * np.prod(imap.pre).astype(int)
+	osizes    = omap.geometry.npixs[omap.active] * np.prod(omap.pre).astype(int)
 	ioffs     = utils.cumsum(isizes)
 	ooffs     = utils.cumsum(osizes)
 	# 4. Build our alltoallv send info

--- a/pixell/utils.py
+++ b/pixell/utils.py
@@ -394,7 +394,7 @@ def weighted_quantile(map, ivar, quantile, axis=-1):
 	and quantile has shape B, then the result will have shape B+A.
 	"""
 	map, ivar = np.broadcast_arrays(map, ivar)
-	quantile  = np.asfarray(quantile)
+	quantile  = np.asarray(quantile, dtype=np.float64)
 	axis      = axis % map.ndim
 	# Move axis to end
 	map       = np.moveaxis(map,  axis, -1)
@@ -408,8 +408,8 @@ def weighted_quantile(map, ivar, quantile, axis=-1):
 	quantile  = quantile.reshape(-1)             # [B]
 	# Sort
 	order     = np.argsort(map, -1)
-	map       = np.asfarray(np.take_along_axis(map,  order, -1))
-	ivar      = np.asfarray(np.take_along_axis(ivar, order, -1))
+	map       = np.asarray(np.take_along_axis(map,  order, -1), dtype=np.float64)
+	ivar      = np.asarray(np.take_along_axis(ivar, order, -1), dtype=np.float64)
 	# We don't have interp or searchsorted for this case, so do it ourselves.
 	# The 0.5 part corresponds to the C=0.5 case in the method
 	icum      = np.cumsum(ivar, axis=-1) # [A,n]
@@ -717,7 +717,7 @@ def grid(box, shape, endpoint=True, axis=0, flat=False):
 		grid([[0],[1]],[4]) => [[0,0000, 0.3333, 0.6667, 1.0000]]
 	"""
 	n    = np.asarray(shape)
-	box  = np.asfarray(box)
+	box  = np.asarray(box, dtype=np.float64)
 	off  = -1 if endpoint else 0
 	inds = np.rollaxis(np.indices(n),0,len(n)+1) # (d1,d2,d3,...,indim)
 	res  = inds * (box[1]-box[0])/(n+off) + box[0]
@@ -2408,7 +2408,7 @@ def tsz_profile_los(x, xc=0.497, alpha=1.0, beta=-4.65, gamma=-0.3, zmax=1e5, np
 		_tsz_profile_los_cache[key] = (interpolate.interp1d(xp, yp, "cubic"), x1, x2, yp[0], yp[-1], (yp[-2]-yp[-1])/(xp[-2]-xp[-1]))
 	spline, xmin, xmax, vleft, vright, slope = _tsz_profile_los_cache[key]
 	# Split into 3 cases: x<xmin, x inside and x > xmax.
-	x     = np.asfarray(x)
+	x     = np.asarray(x, dtype=np.float64)
 	left  = x<xmin
 	right = x>xmax
 	inside= (~left) & (~right)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
     {name = "Mathew Madhavacheril", email = "mathewsyriac@gmail.com"}
 ]
 dependencies = [
-    'numpy>=1.20.0',
+    'numpy',
     'astropy>=2.0',
     'setuptools>=39',
     'h5py>=2.7',
@@ -49,7 +49,7 @@ test = [
     'coverage>=4.5',
     'Sphinx>=1.7',
     'twine>=1.10',
-    'numpy>=1.20',
+    'numpy',
     'astropy>=2.0',
     'setuptools>=39.2',
     'h5py>=2.7',


### PR DESCRIPTION
This PR introduces numpy2 to pixell and tries to compile it for python 3.13. In where `np.asfarray` was used I changed it to `np.asarray(..., dtype=np.float64)`. `np.float64` is the default dtype of `asfarray` when it takes an int as input ([documentation](https://numpy.org/doc/1.26/reference/generated/numpy.asfarray.html#numpy-asfarray)).

It also introduces python3.13.

The purpose is to enable python3.12 and python3.13 and numpy2 to sotodlib (simonsobs/sotodlib#1130).