### PR TITLE
Modify bench.show method to include skip parameter

### DIFF
--- a/pixell/bench.py
+++ b/pixell/bench.py
@@ -67,7 +67,8 @@ class Bench:
 			t2 = tfun()
 			self.add(name, t2-t1)
 	@contextmanager
-	def show(self, name, tfun=None):
+	def show(self, name, tfun=None, skip=False):
+        if skip: continue
 		try:
 			with self.mark(name, tfun=None):
 				yield


### PR DESCRIPTION
Allows one to e.g. skip if rank!=0 in MPI jobs