### PR TITLE
Exclude build/test time dependencies from requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,18 +18,13 @@ maintainers = [
 dependencies = [
     'numpy',
     'astropy>=2.0',
-    'setuptools>=39',
     'h5py>=2.7',
     'scipy>=1.0',
     'python_dateutil>=2.7',
-    'cython',
     'healpy>=1.13',
     'matplotlib>=2.0',
     'pyyaml>=5.0',
     'Pillow>=5.3.0, != 10.4.0',
-    'pytest-cov>=2.6',
-    'coveralls>=1.5',
-    'pytest>=4.6',
     'ducc0>=0.36.0',
     'numba>=0.54.0'
 ]


### PR DESCRIPTION
While packaging in Guix, the system checks which dependencies are required during runtime on the dependent package and fails when `cython`,  `coveralls` , and `pytest` are not included; these are common to include just in build-backend or optional section.